### PR TITLE
Use activityType from Profile for dropdown icon

### DIFF
--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/ui/components/Dropdown.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/ui/components/Dropdown.kt
@@ -67,7 +67,7 @@ fun Course.toDropdownItem(onClick: () -> Unit) = DropdownItem(
 fun Profile.toDropdownItem(onClick: () -> Unit) = DropdownItem(
     text = this.name,
     distance = course?.let { Formatter.distance(it.distance) },
-    activityType = course?.type,
+    activityType = activityType,
     onClick = onClick
 )
 


### PR DESCRIPTION
### Use activityType from Profile for dropdown icon

This PR fixes a minor UI bug where the Profile dropdown was not showing the right icon in same cases.