### PR TITLE
Fix: Handle empty water input to prevent crash

### DIFF
--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/profile/ProfileScreen.kt
@@ -153,7 +153,7 @@ internal fun ProfileForm(
         TextField(
             label = { Text("Water") },
             value = state.profile.water?.toString() ?: "",
-            onValueChange = { if (it.isDigitsOnly()) onEvent(ProfileEvent.SetWater(it.toInt())) },
+            onValueChange = { onEvent(ProfileEvent.SetWater(it.toIntOrNull()))   },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             modifier = Modifier.fillMaxWidth(),
         )

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditScreen.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditScreen.kt
@@ -150,7 +150,7 @@ internal fun QuickEditForm(
                 label = { Text("Water") },
                 value = state.profile.water?.toString() ?: "",
                 modifier = Modifier.fillMaxWidth(),
-                onValueChange = { if (it.isDigitsOnly()) onEvent(QuickEditEvent.SetWater(it.toInt())) },
+                onValueChange = { onEvent(QuickEditEvent.SetWater(it.toIntOrNull()))},
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
             )
         }


### PR DESCRIPTION
### Fix: Handle empty water input to prevent crash

This PR addresses a crash that occurred when the water input field was left without a value.  Instead of crashing, the application now correctly handles this case by setting the water value to null.
