### PR TITLE
Android testing device to SDK 35

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,7 +69,7 @@ android {
             devices {
                 register("pixel9Pro", ManagedVirtualDevice::class) {
                     device = "Pixel 9 Pro"
-                    apiLevel = 34
+                    apiLevel = 35
                     systemImageSource = "aosp"
                 }
             }


### PR DESCRIPTION
### Android testing device to SDK 35

This PR upgrades the Android testing device to SDK 35.
