### PR TITLE
Bump Android Gradle plugin from 8.8.0 to 8.8.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity = "1.10.0"
-androidGradlePlugin = "8.8.0"
+androidGradlePlugin = "8.8.1"
 coil = "3.1.0"
 commonsCsv = "1.13.0"
 compose = "1.7.8"


### PR DESCRIPTION
Bumps Android Gradle plugin from 8.8.0 to 8.8.1

Updates `com.android.application` from 8.8.0 to 8.8.1