### PR TITLE
Bumps androidx.activity:activity-compose from 1.10.0 to 1.10.1.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-activity = "1.10.0"
+activity = "1.10.1"
 androidGradlePlugin = "8.8.2"
 coil = "3.1.0"
 commonsCsv = "1.13.0"


### PR DESCRIPTION
Bumps androidx.activity:activity-compose from 1.10.0 to 1.10.1.