### PR TITLE
Auto-select matching activity

### DIFF
--- a/app/src/androidTest/kotlin/paufregi/connectfeed/data/repository/GarminRepositoryTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/data/repository/GarminRepositoryTest.kt
@@ -34,6 +34,7 @@ import paufregi.connectfeed.stravaDispatcher
 import paufregi.connectfeed.stravaPort
 import paufregi.connectfeed.stravaToken
 import java.io.File
+import java.time.Instant
 import javax.inject.Inject
 import paufregi.connectfeed.core.models.Activity as CoreActivity
 import paufregi.connectfeed.core.models.ActivityType as CoreActivityType
@@ -142,7 +143,8 @@ class GarminRepositoryTest {
                 distance = 17804.00,
                 trainingEffect = "recovery",
                 type = CoreActivityType.Cycling,
-                eventType = CoreEventType.Transportation
+                eventType = CoreEventType.Transportation,
+                date = Instant.ofEpochMilli(1729754100000)
             ),
             CoreActivity(
                 id = 2,
@@ -150,7 +152,8 @@ class GarminRepositoryTest {
                 distance = 17760.00,
                 trainingEffect = "recovery",
                 type = CoreActivityType.Cycling,
-                eventType = CoreEventType.Transportation
+                eventType = CoreEventType.Transportation,
+                date = Instant.ofEpochMilli(1729705968000)
             )
         )
 
@@ -166,8 +169,20 @@ class GarminRepositoryTest {
         stravaStore.saveToken(stravaToken)
 
         val expected = listOf(
-            CoreActivity(id = 1, name = "Happy Friday", distance = 7804.0, type = CoreActivityType.Running),
-            CoreActivity(id = 2, name = "Bondcliff", distance = 23676.0, type = CoreActivityType.Cycling)
+            CoreActivity(
+                id = 1,
+                name = "Happy Friday",
+                distance = 7804.0,
+                type = CoreActivityType.Running,
+                date = Instant.parse("2018-05-02T12:15:09Z")
+            ),
+            CoreActivity(
+                id = 2,
+                name = "Bondcliff",
+                distance = 23676.0,
+                type = CoreActivityType.Cycling,
+                date = Instant.parse("2018-04-30T12:35:51Z")
+                )
         )
 
         val res = repo.getLatestStravaActivities(5)

--- a/app/src/main/kotlin/paufregi/connectfeed/core/models/Activity.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/core/models/Activity.kt
@@ -1,5 +1,7 @@
 package paufregi.connectfeed.core.models
 
+import java.time.Instant
+
 data class Activity(
     val id: Long,
     val name: String,
@@ -7,4 +9,9 @@ data class Activity(
     val eventType: EventType? = null,
     val distance: Double? = null,
     val trainingEffect: String? = null,
-)
+    val date: Instant? = null
+) {
+    fun match(other: Activity): Boolean {
+        return this.type == other.type && this.date == other.date
+    }
+}

--- a/app/src/main/kotlin/paufregi/connectfeed/data/api/garmin/models/Activity.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/data/api/garmin/models/Activity.kt
@@ -4,6 +4,7 @@ import androidx.annotation.Keep
 import com.google.gson.annotations.SerializedName
 import kotlinx.serialization.Serializable
 import paufregi.connectfeed.data.api.garmin.converters.TrainingEffectConverter
+import java.time.Instant
 import kotlin.math.round
 import paufregi.connectfeed.core.models.Activity as CoreActivity
 
@@ -22,6 +23,8 @@ data class Activity(
     val distance: Double,
     @SerializedName("trainingEffectLabel")
     val trainingEffectLabel: String?,
+    @SerializedName("beginTimestamp")
+    val beginTimestamp: Long?,
 ) {
     fun toCore(): CoreActivity =
         CoreActivity(
@@ -30,6 +33,7 @@ data class Activity(
             type = this.type.toCore(),
             eventType = this.eventType?.toCore(),
             distance = round(this.distance),
-            trainingEffect = TrainingEffectConverter.convert(this.trainingEffectLabel)
+            trainingEffect = TrainingEffectConverter.convert(this.trainingEffectLabel),
+            date = this.beginTimestamp?.let { Instant.ofEpochMilli(it) }
         )
 }

--- a/app/src/main/kotlin/paufregi/connectfeed/data/api/strava/models/Activity.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/data/api/strava/models/Activity.kt
@@ -4,6 +4,7 @@ import androidx.annotation.Keep
 import com.google.gson.annotations.SerializedName
 import kotlinx.serialization.Serializable
 import paufregi.connectfeed.data.api.strava.converters.SportTypeConverter
+import java.time.Instant
 import kotlin.math.round
 import paufregi.connectfeed.core.models.Activity as CoreActivity
 
@@ -18,11 +19,14 @@ data class Activity(
     val sportType: String,
     @SerializedName("distance")
     val distance: Double,
+    @SerializedName("start_date")
+    val startDate: String?,
 ) {
     fun toCore(): CoreActivity = CoreActivity(
         id = id,
         name = name,
         distance = round(this.distance),
         type = SportTypeConverter.toActivityType(sportType),
+        date = Instant.parse(this.startDate)
     )
 }

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditViewModel.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditViewModel.kt
@@ -59,16 +59,22 @@ class QuickEditViewModel @Inject constructor(
         is QuickEditAction.SetActivity -> _state.update {
             it.copy(
                 activity = event.activity,
-                stravaActivity = if (it.stravaActivity?.type != event.activity.type) null else it.stravaActivity,
                 profile = if (it.profile?.activityType != event.activity.type) null else it.profile,
+                stravaActivity = if ((it.stravaActivity == null) || (it.stravaActivity.type != event.activity.type))
+                    it.stravaActivities.find { it.match(event.activity) }
+                else
+                    it.stravaActivity,
             )
         }
 
         is QuickEditAction.SetStravaActivity -> _state.update {
             it.copy(
                 stravaActivity = event.activity,
-                activity = if (it.activity?.type != event.activity.type) null else it.activity,
                 profile = if (it.profile?.activityType != event.activity.type) null else it.profile,
+                activity = if ((it.activity == null) || (it.activity.type != event.activity.type))
+                    it.activities.find { it.match(event.activity) }
+                else
+                    it.activity,
             )
         }
 

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/ui/components/NavigationBar.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/ui/components/NavigationBar.kt
@@ -1,8 +1,6 @@
 package paufregi.connectfeed.presentation.ui.components
 
 import androidx.compose.material3.Icon
-import androidx.compose.material3.NavigationBar as MaterialNavigationBar
-import androidx.compose.material3.NavigationBarItem as MaterialNavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -10,6 +8,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.util.fastForEachIndexed
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import androidx.compose.material3.NavigationBar as MaterialNavigationBar
+import androidx.compose.material3.NavigationBarItem as MaterialNavigationBarItem
 
 @Composable
 fun NavigationBar(

--- a/app/src/test/kotlin/paufregi/connectfeed/core/models/ActivityTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/core/models/ActivityTest.kt
@@ -1,0 +1,56 @@
+package paufregi.connectfeed.core.models
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.time.Instant
+
+class ActivityTest {
+
+    @Test
+    fun `Match activity`() {
+        val activity1 = Activity(
+            id = 1,
+            name = "Activity 1",
+            distance = 17804.00,
+            trainingEffect = "recovery",
+            type = ActivityType.Cycling,
+            eventType = EventType.Transportation,
+            date = Instant.ofEpochMilli(1729754100000)
+        )
+
+        val activity2 = Activity(
+            id = 2,
+            name = "Activity 2",
+            distance = 7804.00,
+            trainingEffect = "recovery",
+            type = ActivityType.Cycling,
+            date = Instant.ofEpochMilli(1729754100000)
+        )
+
+        assertThat(activity1.match(activity2)).isTrue()
+    }
+
+    @Test
+    fun `No match activity`() {
+        val activity1 = Activity(
+            id = 1,
+            name = "Activity 1",
+            distance = 17804.00,
+            trainingEffect = "recovery",
+            type = ActivityType.Cycling,
+            eventType = EventType.Transportation,
+            date = Instant.ofEpochMilli(1729754100000)
+        )
+
+        val activity2 = Activity(
+            id = 2,
+            name = "Activity 2",
+            distance = 7804.00,
+            trainingEffect = "recovery",
+            type = ActivityType.Cycling,
+            date = Instant.ofEpochMilli(1729754500000)
+        )
+
+        assertThat(activity1.match(activity2)).isFalse()
+    }
+}

--- a/app/src/test/kotlin/paufregi/connectfeed/data/api/garmin/GarminConnectTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/data/api/garmin/GarminConnectTest.kt
@@ -125,7 +125,8 @@ class GarminConnectTest {
                 distance = 17803.69921875,
                 trainingEffectLabel = "RECOVERY",
                 type = ActivityType(id = 10, key = "road_biking"),
-                eventType = EventType(id = 5, key = "transportation")
+                eventType = EventType(id = 5, key = "transportation"),
+                beginTimestamp = 1729754100000
             ),
             Activity(
                 id = 2,
@@ -133,7 +134,8 @@ class GarminConnectTest {
                 distance = 17759.779296875,
                 trainingEffectLabel = "RECOVERY",
                 type = ActivityType(id = 10, key = "road_biking"),
-                eventType = EventType(id = 5, key = "transportation")
+                eventType = EventType(id = 5, key = "transportation"),
+                beginTimestamp = 1729705968000
             )
         )
 

--- a/app/src/test/kotlin/paufregi/connectfeed/data/api/garmin/models/ActivityTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/data/api/garmin/models/ActivityTest.kt
@@ -2,6 +2,7 @@ package paufregi.connectfeed.data.api.garmin.models
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import java.time.Instant
 import paufregi.connectfeed.core.models.Activity as CoreActivity
 import paufregi.connectfeed.core.models.ActivityType as CoreActivityType
 import paufregi.connectfeed.core.models.EventType as CoreEventType
@@ -16,7 +17,8 @@ class ActivityTest {
             distance = 15007.59,
             type = ActivityType(id = 1, key = "running"),
             eventType = EventType(id = 4, key = "training"),
-            trainingEffectLabel = "TEMPO"
+            trainingEffectLabel = "TEMPO",
+            beginTimestamp = 1735693200000
         )
 
         val coreActivity = CoreActivity(
@@ -25,7 +27,8 @@ class ActivityTest {
             type = CoreActivityType.Running,
             eventType = CoreEventType.Training,
             distance = 15008.00,
-            trainingEffect = "tempo"
+            trainingEffect = "tempo",
+            date = Instant.ofEpochMilli(1735693200000)
         )
 
         assertThat(activity.toCore()).isEqualTo(coreActivity)

--- a/app/src/test/kotlin/paufregi/connectfeed/data/api/strava/StravaTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/data/api/strava/StravaTest.kt
@@ -56,14 +56,15 @@ class StravaTest {
                 id = 1,
                 name = "Happy Friday",
                 distance = 7803.6,
-                sportType = "Run"
-
+                sportType = "Run",
+                startDate = "2018-05-02T12:15:09Z"
             ),
             Activity(
                 id = 2,
                 name = "Bondcliff",
                 distance = 23676.5,
-                sportType = "Ride"
+                sportType = "Ride",
+                startDate = "2018-04-30T12:35:51Z"
             )
         )
 

--- a/app/src/test/kotlin/paufregi/connectfeed/data/api/strava/models/ActivityTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/data/api/strava/models/ActivityTest.kt
@@ -2,6 +2,7 @@ package paufregi.connectfeed.data.api.strava.models
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import java.time.Instant
 import paufregi.connectfeed.core.models.Activity as CoreActivity
 import paufregi.connectfeed.core.models.ActivityType as CoreActivityType
 
@@ -13,14 +14,16 @@ class ActivityTest {
             id = 1,
             name = "name",
             distance = 15007.59123,
-            sportType = "Run"
+            sportType = "Run",
+            startDate = "2024-01-01T01:00:00Z",
         )
 
         val coreActivity = CoreActivity(
             id = 1,
             name = "name",
             distance = 15008.00,
-            type = CoreActivityType.Running
+            type = CoreActivityType.Running,
+            date = Instant.parse("2024-01-01T01:00:00Z")
         )
 
         assertThat(activity.toCore()).isEqualTo(coreActivity)

--- a/app/src/test/kotlin/paufregi/connectfeed/data/repository/GarminRepositoryTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/data/repository/GarminRepositoryTest.kt
@@ -251,7 +251,8 @@ class GarminRepositoryTest {
                 distance = 10234.00,
                 trainingEffectLabel = "recovery",
                 type = ActivityType(id = 1, key = "running"),
-                eventType = EventType(id = 4, key = "training")
+                eventType = EventType(id = 4, key = "training"),
+                beginTimestamp = 1729754100000
             ),
             Activity(
                 id = 2,
@@ -259,7 +260,8 @@ class GarminRepositoryTest {
                 distance = 17759.00,
                 trainingEffectLabel = "recovery",
                 type = ActivityType(id = 10, key = "road_biking"),
-                eventType = EventType(id = 4, key = "training")
+                eventType = EventType(id = 4, key = "training"),
+                beginTimestamp = 1729705968000
             )
         )
         coEvery { connect.getLatestActivities(any()) } returns Response.success(activities)
@@ -315,8 +317,20 @@ class GarminRepositoryTest {
     @Test
     fun `Get latest Strava activities`() = runTest {
         val activities = listOf(
-            StravaActivity(id = 1, name = "activity_1", distance = 10234.00, sportType = "Run"),
-            StravaActivity(id = 2, name = "activity_2", distance = 17759.00, sportType = "Ride")
+            StravaActivity(
+                id = 1,
+                name = "activity_1",
+                distance = 10234.00,
+                sportType = "Run",
+                startDate = "2018-05-02T12:15:09Z"
+            ),
+            StravaActivity(
+                id = 2,
+                name = "activity_2",
+                distance = 17759.00,
+                sportType = "Ride",
+                startDate = "2018-04-30T12:35:51Z"
+            )
         )
         coEvery { strava.getLatestActivities(perPage = any()) } returns Response.success(activities)
 

--- a/app/src/test/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditViewModelTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditViewModelTest.kt
@@ -28,6 +28,7 @@ import paufregi.connectfeed.core.usecases.UpdateActivity
 import paufregi.connectfeed.core.usecases.UpdateStravaActivity
 import paufregi.connectfeed.presentation.ui.models.ProcessState
 import paufregi.connectfeed.presentation.utils.MainDispatcherRule
+import java.time.Instant
 
 @ExperimentalCoroutinesApi
 class QuickEditViewModelTest {
@@ -50,7 +51,8 @@ class QuickEditViewModelTest {
             type = ActivityType.Running,
             eventType = EventType.Training,
             distance = 10234.00,
-            trainingEffect = "recovery"
+            trainingEffect = "recovery",
+            date = Instant.ofEpochMilli(1735693200000)
         ),
         Activity(
             id = 2L,
@@ -58,8 +60,18 @@ class QuickEditViewModelTest {
             type = ActivityType.Cycling,
             eventType = EventType.Training,
             distance = 17803.00,
-            trainingEffect = "base"
-        )
+            trainingEffect = "base",
+            date = Instant.ofEpochMilli(1729705968000)
+        ),
+        Activity(
+            id = 3L,
+            name = "Running2",
+            type = ActivityType.Running,
+            eventType = EventType.Training,
+            distance = 5234.00,
+            trainingEffect = "base",
+            date = Instant.ofEpochMilli(1729705968000)
+        ),
     )
 
     val stravaActivities = listOf(
@@ -67,14 +79,23 @@ class QuickEditViewModelTest {
             id = 1L,
             name = "StravaRunning",
             type = ActivityType.Running,
-            distance = 10234.00
+            distance = 10234.00,
+            date = Instant.ofEpochMilli(1735693200000)
         ),
         Activity(
             id = 2L,
             name = "StravaCycling",
             type = ActivityType.Cycling,
-            distance = 17803.00
-        )
+            distance = 17803.00,
+            date = Instant.ofEpochMilli(1729705968000)
+        ),
+        Activity(
+            id = 3L,
+            name = "StravaRunning2",
+            type = ActivityType.Running,
+            distance = 5234.00,
+            date = Instant.ofEpochMilli(1729705968000)
+        ),
     )
 
     val profiles = listOf(
@@ -304,7 +325,7 @@ class QuickEditViewModelTest {
             assertThat(state.stravaActivities).isEqualTo(stravaActivities)
             assertThat(state.profiles).isEqualTo(profiles)
             assertThat(state.activity).isEqualTo(activities[0])
-            assertThat(state.stravaActivity).isNull()
+            assertThat(state.stravaActivity).isEqualTo(stravaActivities[0])
             assertThat(state.profile).isNull()
             assertThat(state.description).isNull()
             assertThat(state.effort).isNull()
@@ -333,7 +354,7 @@ class QuickEditViewModelTest {
             awaitItem() // skip initial state
             viewModel.onAction(QuickEditAction.SetProfile(profiles[0]))
             awaitItem() // skip
-            viewModel.onAction(QuickEditAction.SetStravaActivity(stravaActivities[0]))
+            viewModel.onAction(QuickEditAction.SetStravaActivity(stravaActivities[2]))
             awaitItem() // skip
             viewModel.onAction(QuickEditAction.SetActivity(activities[0]))
             val state = awaitItem()
@@ -342,7 +363,7 @@ class QuickEditViewModelTest {
             assertThat(state.stravaActivities).isEqualTo(stravaActivities)
             assertThat(state.profiles).isEqualTo(profiles)
             assertThat(state.activity).isEqualTo(activities[0])
-            assertThat(state.stravaActivity).isEqualTo(stravaActivities[0])
+            assertThat(state.stravaActivity).isEqualTo(stravaActivities[2])
             assertThat(state.profile).isEqualTo(profiles[0])
             assertThat(state.description).isNull()
             assertThat(state.effort).isNull()
@@ -380,7 +401,7 @@ class QuickEditViewModelTest {
             assertThat(state.stravaActivities).isEqualTo(stravaActivities)
             assertThat(state.profiles).isEqualTo(profiles)
             assertThat(state.activity).isEqualTo(activities[0])
-            assertThat(state.stravaActivity).isNull()
+            assertThat(state.stravaActivity).isEqualTo(stravaActivities[0])
             assertThat(state.profile).isNull()
             assertThat(state.description).isNull()
             assertThat(state.effort).isNull()
@@ -413,7 +434,7 @@ class QuickEditViewModelTest {
             assertThat(state.activities).isEqualTo(activities)
             assertThat(state.stravaActivities).isEqualTo(stravaActivities)
             assertThat(state.profiles).isEqualTo(profiles)
-            assertThat(state.activity).isNull()
+            assertThat(state.activity).isEqualTo(activities[0])
             assertThat(state.stravaActivity).isEqualTo(stravaActivities[0])
             assertThat(state.profile).isNull()
             assertThat(state.description).isNull()
@@ -443,7 +464,7 @@ class QuickEditViewModelTest {
             awaitItem() // skip initial state
             viewModel.onAction(QuickEditAction.SetProfile(profiles[0]))
             awaitItem() // skip
-            viewModel.onAction(QuickEditAction.SetActivity(activities[0]))
+            viewModel.onAction(QuickEditAction.SetActivity(activities[2]))
             awaitItem() // skip
             viewModel.onAction(QuickEditAction.SetStravaActivity(stravaActivities[0]))
             val state = awaitItem()
@@ -451,7 +472,7 @@ class QuickEditViewModelTest {
             assertThat(state.activities).isEqualTo(activities)
             assertThat(state.stravaActivities).isEqualTo(stravaActivities)
             assertThat(state.profiles).isEqualTo(profiles)
-            assertThat(state.activity).isEqualTo(activities[0])
+            assertThat(state.activity).isEqualTo(activities[2])
             assertThat(state.stravaActivity).isEqualTo(stravaActivities[0])
             assertThat(state.profile).isEqualTo(profiles[0])
             assertThat(state.description).isNull()
@@ -489,7 +510,7 @@ class QuickEditViewModelTest {
             assertThat(state.activities).isEqualTo(activities)
             assertThat(state.stravaActivities).isEqualTo(stravaActivities)
             assertThat(state.profiles).isEqualTo(profiles)
-            assertThat(state.activity).isNull()
+            assertThat(state.activity).isEqualTo(activities[0])
             assertThat(state.stravaActivity).isEqualTo(stravaActivities[0])
             assertThat(state.profile).isNull()
             assertThat(state.description).isNull()
@@ -665,8 +686,6 @@ class QuickEditViewModelTest {
             awaitItem() // skip initial state
             viewModel.onAction(QuickEditAction.SetActivity(activities[0]))
             awaitItem() // skip
-            viewModel.onAction(QuickEditAction.SetStravaActivity(stravaActivities[0]))
-            awaitItem() // skip
             viewModel.onAction(QuickEditAction.SetProfile(profiles[0]))
             awaitItem() // skip
             viewModel.onAction(QuickEditAction.SetEffort(80f))
@@ -734,8 +753,6 @@ class QuickEditViewModelTest {
             awaitItem() // skip initial state
             viewModel.onAction(QuickEditAction.SetActivity(activities[0]))
             awaitItem() // skip
-            viewModel.onAction(QuickEditAction.SetStravaActivity(stravaActivities[0]))
-            awaitItem() // skip
             viewModel.onAction(QuickEditAction.SetProfile(profiles[0]))
             awaitItem() // skip
             viewModel.onAction(QuickEditAction.SetEffort(80f))
@@ -796,8 +813,6 @@ class QuickEditViewModelTest {
             awaitItem() // skip initial state
             viewModel.onAction(QuickEditAction.SetActivity(activities[0]))
             awaitItem() // skip
-            viewModel.onAction(QuickEditAction.SetStravaActivity(stravaActivities[0]))
-            awaitItem() // skip
             viewModel.onAction(QuickEditAction.SetProfile(profiles[0]))
             awaitItem() // skip
             viewModel.onAction(QuickEditAction.SetEffort(80f))
@@ -857,8 +872,6 @@ class QuickEditViewModelTest {
         viewModel.state.test {
             awaitItem() // skip initial state
             viewModel.onAction(QuickEditAction.SetActivity(activities[0]))
-            awaitItem() // skip
-            viewModel.onAction(QuickEditAction.SetStravaActivity(stravaActivities[0]))
             awaitItem() // skip
             viewModel.onAction(QuickEditAction.SetProfile(profiles[0]))
             awaitItem() // skip

--- a/app/src/test/kotlin/paufregi/connectfeed/presentation/syncstrava/SyncStravaViewModelTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/presentation/syncstrava/SyncStravaViewModelTest.kt
@@ -22,6 +22,7 @@ import paufregi.connectfeed.core.usecases.GetLatestStravaActivities
 import paufregi.connectfeed.core.usecases.SyncStravaActivity
 import paufregi.connectfeed.presentation.ui.models.ProcessState
 import paufregi.connectfeed.presentation.utils.MainDispatcherRule
+import java.time.Instant
 
 @ExperimentalCoroutinesApi
 class SyncStravaViewModelTest {
@@ -51,7 +52,16 @@ class SyncStravaViewModelTest {
             eventType = EventType.Training,
             distance = 17803.00,
             trainingEffect = "base"
-        )
+        ),
+        Activity(
+            id = 3L,
+            name = "Running2",
+            type = ActivityType.Running,
+            eventType = EventType.Training,
+            distance = 5234.00,
+            trainingEffect = "base",
+            date = Instant.ofEpochMilli(1729705968000)
+        ),
     )
 
     val stravaActivities = listOf(
@@ -66,7 +76,14 @@ class SyncStravaViewModelTest {
             name = "StravaCycling",
             type = ActivityType.Cycling,
             distance = 17803.00
-        )
+        ),
+        Activity(
+            id = 3L,
+            name = "StravaRunning2",
+            type = ActivityType.Running,
+            distance = 5234.00,
+            date = Instant.ofEpochMilli(1729705968000)
+        ),
     )
 
     @Before
@@ -198,7 +215,7 @@ class SyncStravaViewModelTest {
             assertThat(state.activities).isEqualTo(activities)
             assertThat(state.stravaActivities).isEqualTo(stravaActivities)
             assertThat(state.activity).isEqualTo(activities[0])
-            assertThat(state.stravaActivity).isNull()
+            assertThat(state.stravaActivity).isEqualTo(stravaActivities[0])
             assertThat(state.description).isNull()
             assertThat(state.trainingEffect).isFalse()
             cancelAndIgnoreRemainingEvents()
@@ -220,7 +237,7 @@ class SyncStravaViewModelTest {
 
         viewModel.state.test {
             awaitItem() // skip initial state
-            viewModel.onAction(SyncStravaAction.SetStravaActivity(stravaActivities[0]))
+            viewModel.onAction(SyncStravaAction.SetStravaActivity(stravaActivities[2]))
             awaitItem() // skip
             viewModel.onAction(SyncStravaAction.SetActivity(activities[0]))
             val state = awaitItem()
@@ -228,7 +245,7 @@ class SyncStravaViewModelTest {
             assertThat(state.activities).isEqualTo(activities)
             assertThat(state.stravaActivities).isEqualTo(stravaActivities)
             assertThat(state.activity).isEqualTo(activities[0])
-            assertThat(state.stravaActivity).isEqualTo(stravaActivities[0])
+            assertThat(state.stravaActivity).isEqualTo(stravaActivities[2])
             assertThat(state.description).isNull()
             assertThat(state.trainingEffect).isFalse()
             cancelAndIgnoreRemainingEvents()
@@ -258,7 +275,7 @@ class SyncStravaViewModelTest {
             assertThat(state.activities).isEqualTo(activities)
             assertThat(state.stravaActivities).isEqualTo(stravaActivities)
             assertThat(state.activity).isEqualTo(activities[0])
-            assertThat(state.stravaActivity).isNull()
+            assertThat(state.stravaActivity).isEqualTo(stravaActivities[0])
             assertThat(state.description).isNull()
             assertThat(state.trainingEffect).isFalse()
             cancelAndIgnoreRemainingEvents()
@@ -285,7 +302,7 @@ class SyncStravaViewModelTest {
             assertThat(state.process).isEqualTo(ProcessState.Idle)
             assertThat(state.activities).isEqualTo(activities)
             assertThat(state.stravaActivities).isEqualTo(stravaActivities)
-            assertThat(state.activity).isNull()
+            assertThat(state.activity).isEqualTo(activities[0])
             assertThat(state.stravaActivity).isEqualTo(stravaActivities[0])
             assertThat(state.description).isNull()
             assertThat(state.trainingEffect).isFalse()
@@ -308,14 +325,14 @@ class SyncStravaViewModelTest {
 
         viewModel.state.test {
             awaitItem() // skip initial state
-            viewModel.onAction(SyncStravaAction.SetActivity(activities[0]))
+            viewModel.onAction(SyncStravaAction.SetActivity(activities[2]))
             awaitItem() // skip
             viewModel.onAction(SyncStravaAction.SetStravaActivity(stravaActivities[0]))
             val state = awaitItem()
             assertThat(state.process).isEqualTo(ProcessState.Idle)
             assertThat(state.activities).isEqualTo(activities)
             assertThat(state.stravaActivities).isEqualTo(stravaActivities)
-            assertThat(state.activity).isEqualTo(activities[0])
+            assertThat(state.activity).isEqualTo(activities[2])
             assertThat(state.stravaActivity).isEqualTo(stravaActivities[0])
             assertThat(state.description).isNull()
             assertThat(state.trainingEffect).isFalse()
@@ -345,7 +362,7 @@ class SyncStravaViewModelTest {
             assertThat(state.process).isEqualTo(ProcessState.Idle)
             assertThat(state.activities).isEqualTo(activities)
             assertThat(state.stravaActivities).isEqualTo(stravaActivities)
-            assertThat(state.activity).isNull()
+            assertThat(state.activity).isEqualTo(activities[0])
             assertThat(state.stravaActivity).isEqualTo(stravaActivities[0])
             assertThat(state.description).isNull()
             assertThat(state.trainingEffect).isFalse()
@@ -427,8 +444,6 @@ class SyncStravaViewModelTest {
             awaitItem() // skip initial state
             viewModel.onAction(SyncStravaAction.SetActivity(activities[0]))
             awaitItem() // skip
-            viewModel.onAction(SyncStravaAction.SetStravaActivity(stravaActivities[0]))
-            awaitItem() // skip
             viewModel.onAction(SyncStravaAction.SetDescription("description"))
             awaitItem() // skip
             viewModel.onAction(SyncStravaAction.SetTrainingEffect(true))
@@ -468,8 +483,6 @@ class SyncStravaViewModelTest {
         viewModel.state.test {
             awaitItem() // skip initial state
             viewModel.onAction(SyncStravaAction.SetActivity(activities[0]))
-            awaitItem() // skip
-            viewModel.onAction(SyncStravaAction.SetStravaActivity(stravaActivities[0]))
             awaitItem() // skip
             viewModel.onAction(SyncStravaAction.SetDescription("description"))
             awaitItem() // skip


### PR DESCRIPTION
### Auto-select matching activity

This PR introduces a new feature that enhances the activity selection process by automatically selecting a corresponding Strava activity when a Garmin activity is chosen, and vice-versa. 
The matching is based on the following criteria:

* **Same Activity Type:** The selected activities must be of the same type (e.g., running, cycling).
* **Timestamp Matching:** The timestamps of the activities must be closely aligned.
