### PR TITLE
Reset button for QuickEdit and SyncStrava

### DIFF
--- a/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditScreenTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditScreenTest.kt
@@ -78,6 +78,7 @@ class QuickEditScreenTest {
         composeTestRule.onNodeWithText("Activity").isDisplayed()
         composeTestRule.onNodeWithText("Profile").isDisplayed()
         composeTestRule.onNodeWithTag("navigation_bar").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("Reset").assertIsEnabled()
         composeTestRule.onNodeWithText("Save").assertIsNotEnabled()
     }
 
@@ -95,6 +96,7 @@ class QuickEditScreenTest {
         composeTestRule.onNodeWithText("Strava").isDisplayed()
         composeTestRule.onNodeWithText("Profile").isDisplayed()
         composeTestRule.onNodeWithTag("navigation_bar").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Reset").assertIsEnabled()
         composeTestRule.onNodeWithText("Save").assertIsNotEnabled()
     }
 
@@ -112,6 +114,7 @@ class QuickEditScreenTest {
         composeTestRule.onNodeWithText("Activity").assertTextContains(activities[0].name)
         composeTestRule.onNodeWithText("Profile").assertTextContains(profiles[0].name)
         composeTestRule.onNodeWithTag("navigation_bar").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("Reset").assertIsEnabled()
         composeTestRule.onNodeWithText("Save").assertIsEnabled()
     }
 
@@ -132,6 +135,7 @@ class QuickEditScreenTest {
         composeTestRule.onNodeWithText("Strava Activity").assertTextContains(stravaActivities[0].name)
         composeTestRule.onNodeWithText("Profile").assertTextContains(profiles[0].name)
         composeTestRule.onNodeWithTag("navigation_bar").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Reset").assertIsEnabled()
         composeTestRule.onNodeWithText("Save").assertIsEnabled()
     }
 

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/syncstrava/SyncStravaScreenTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/syncstrava/SyncStravaScreenTest.kt
@@ -70,6 +70,7 @@ class SyncStravaScreenTest {
         composeTestRule.onNodeWithText("Activity").isDisplayed()
         composeTestRule.onNodeWithText("Strava activity").isDisplayed()
         composeTestRule.onNodeWithTag("navigation_bar").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Reset").assertIsEnabled()
         composeTestRule.onNodeWithText("Save").assertIsNotEnabled()
     }
 
@@ -87,6 +88,7 @@ class SyncStravaScreenTest {
         composeTestRule.onNodeWithText("Activity").assertTextContains(activities[0].name)
         composeTestRule.onNodeWithText("Strava Activity").assertTextContains(stravaActivities[0].name)
         composeTestRule.onNodeWithTag("navigation_bar").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Reset").assertIsEnabled()
         composeTestRule.onNodeWithText("Save").assertIsEnabled()
     }
 

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/account/AccountScreen.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/account/AccountScreen.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -27,6 +29,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -131,8 +134,13 @@ internal fun AccountForm(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .fillMaxSize()
-            .padding(paddingValues)
-            .padding(horizontal = 20.dp)
+            .verticalScroll(rememberScrollState())
+            .padding(
+                top = paddingValues.calculateTopPadding(),
+                bottom = paddingValues.calculateBottomPadding(),
+                start = paddingValues.calculateLeftPadding(LayoutDirection.Ltr) + 20.dp,
+                end = paddingValues.calculateRightPadding(LayoutDirection.Ltr) + 20.dp,
+            )
             .testTag("account_form")
     ) {
 

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/profile/ProfileScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -106,9 +107,13 @@ internal fun ProfileForm(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .fillMaxSize()
-            .padding(paddingValues)
-            .padding(horizontal = 20.dp)
             .verticalScroll(rememberScrollState())
+            .padding(
+                top = paddingValues.calculateTopPadding(),
+                bottom = paddingValues.calculateBottomPadding(),
+                start = paddingValues.calculateLeftPadding(LayoutDirection.Ltr) + 20.dp,
+                end = paddingValues.calculateRightPadding(LayoutDirection.Ltr) + 20.dp,
+            )
             .testTag("profile_form")
     ) {
         TextField(

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditScreen.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditScreen.kt
@@ -232,9 +232,16 @@ internal fun QuickEditForm(
             }
         }
         Row(
-            horizontalArrangement = Arrangement.End,
-            modifier = Modifier.fillMaxWidth()
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
         ) {
+            Button(
+                text = "Reset",
+                onClick = { onAction(QuickEditAction.Restart) }
+            )
+
             Button(
                 text = "Save",
                 enabled = state.activity != null && state.profile != null &&

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditScreen.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditScreen.kt
@@ -8,7 +8,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Slider
@@ -25,6 +27,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -132,8 +135,13 @@ internal fun QuickEditForm(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .fillMaxSize()
-            .padding(paddingValues)
-            .padding(horizontal = 20.dp)
+            .verticalScroll(rememberScrollState())
+            .padding(
+                top = paddingValues.calculateTopPadding(),
+                bottom = paddingValues.calculateBottomPadding(),
+                start = paddingValues.calculateLeftPadding(LayoutDirection.Ltr) + 20.dp,
+                end = paddingValues.calculateRightPadding(LayoutDirection.Ltr) + 20.dp,
+            )
             .testTag("quick_edit_form")
     ) {
         val interactionSource = remember { MutableInteractionSource() }

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/syncstrava/SyncStravaScreen.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/syncstrava/SyncStravaScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
@@ -23,6 +25,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -117,8 +120,13 @@ internal fun SyncStravaForm(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .fillMaxSize()
-            .padding(paddingValues)
-            .padding(horizontal = 20.dp)
+            .verticalScroll(rememberScrollState())
+            .padding(
+                top = paddingValues.calculateTopPadding(),
+                bottom = paddingValues.calculateBottomPadding(),
+                start = paddingValues.calculateLeftPadding(LayoutDirection.Ltr) + 20.dp,
+                end = paddingValues.calculateRightPadding(LayoutDirection.Ltr) + 20.dp,
+            )
             .testTag("sync_strava_form")
     ) {
         remember { MutableInteractionSource() }

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/syncstrava/SyncStravaScreen.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/syncstrava/SyncStravaScreen.kt
@@ -162,9 +162,15 @@ internal fun SyncStravaForm(
             Text("Training Effect")
         }
         Row(
-            horizontalArrangement = Arrangement.End,
-            modifier = Modifier.fillMaxWidth()
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
         ) {
+            Button(
+                text = "Reset",
+                onClick = { onAction(SyncStravaAction.Restart) }
+            )
             Button(
                 text = "Save",
                 enabled = state.activity != null && state.stravaActivity != null,

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/ui/components/IconRadioGroup.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/ui/components/IconRadioGroup.kt
@@ -50,7 +50,7 @@ fun <T> IconRadioGroup(
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onPrimaryContainer,
                     modifier = Modifier
-                        .padding(top = 5.dp)
+                        .padding(top = 7.dp)
                         .align(Alignment.Center)
                         .size(if (isSelected) 46.dp else 38.dp)
                         .alpha(if (isSelected) 1f else 0.5f)


### PR DESCRIPTION
### Reset button for QuickEdit and SyncStrava

This PR introduce a Reset button for QuickEdit and SyncStrava. This button reset the whole form and refetch activities from API.
Additionally optional vertical scrolls are added to the several screen and padding values are propagated correctly now.

