### PR TITLE
Relax Activity matching

### DIFF
--- a/app/src/main/kotlin/paufregi/connectfeed/core/models/Activity.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/core/models/Activity.kt
@@ -1,5 +1,6 @@
 package paufregi.connectfeed.core.models
 
+import java.time.Duration
 import java.time.Instant
 
 data class Activity(
@@ -12,6 +13,8 @@ data class Activity(
     val date: Instant? = null
 ) {
     fun match(other: Activity): Boolean {
-        return this.type == other.type && this.date == other.date
+        return this.type == other.type &&
+                (this.date != null && other.date != null &&
+                Duration.between(this.date, other.date).abs() <= Duration.ofMinutes(1))
     }
 }

--- a/app/src/test/kotlin/paufregi/connectfeed/core/models/ActivityTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/core/models/ActivityTest.kt
@@ -15,7 +15,7 @@ class ActivityTest {
             trainingEffect = "recovery",
             type = ActivityType.Cycling,
             eventType = EventType.Transportation,
-            date = Instant.ofEpochMilli(1729754100000)
+            date = Instant.parse("2025-01-01T01:01:00Z")
         )
 
         val activity2 = Activity(
@@ -24,14 +24,14 @@ class ActivityTest {
             distance = 7804.00,
             trainingEffect = "recovery",
             type = ActivityType.Cycling,
-            date = Instant.ofEpochMilli(1729754100000)
+            date = Instant.parse("2025-01-01T01:01:30Z")
         )
 
         assertThat(activity1.match(activity2)).isTrue()
     }
 
     @Test
-    fun `No match activity`() {
+    fun `No match - no timestamp`() {
         val activity1 = Activity(
             id = 1,
             name = "Activity 1",
@@ -39,7 +39,7 @@ class ActivityTest {
             trainingEffect = "recovery",
             type = ActivityType.Cycling,
             eventType = EventType.Transportation,
-            date = Instant.ofEpochMilli(1729754100000)
+            date = null
         )
 
         val activity2 = Activity(
@@ -48,7 +48,79 @@ class ActivityTest {
             distance = 7804.00,
             trainingEffect = "recovery",
             type = ActivityType.Cycling,
-            date = Instant.ofEpochMilli(1729754500000)
+            date = Instant.parse("2025-01-01T01:02:00Z")
+        )
+
+        assertThat(activity1.match(activity2)).isFalse()
+    }
+
+    @Test
+    fun `No match - no timestamp in parameter`() {
+        val activity1 = Activity(
+            id = 1,
+            name = "Activity 1",
+            distance = 17804.00,
+            trainingEffect = "recovery",
+            type = ActivityType.Cycling,
+            eventType = EventType.Transportation,
+            date = Instant.parse("2025-01-01T01:01:00Z")
+        )
+
+        val activity2 = Activity(
+            id = 2,
+            name = "Activity 2",
+            distance = 7804.00,
+            trainingEffect = "recovery",
+            type = ActivityType.Cycling,
+            date = null
+        )
+
+        assertThat(activity1.match(activity2)).isFalse()
+    }
+
+    @Test
+    fun `No match - different type`() {
+        val activity1 = Activity(
+            id = 1,
+            name = "Activity 1",
+            distance = 7804.00,
+            trainingEffect = "recovery",
+            type = ActivityType.Running,
+            eventType = EventType.Transportation,
+            date = Instant.parse("2025-01-01T01:01:00Z")
+        )
+
+        val activity2 = Activity(
+            id = 2,
+            name = "Activity 2",
+            distance = 17804.00,
+            trainingEffect = "recovery",
+            type = ActivityType.Cycling,
+            date = Instant.parse("2025-01-01T01:01:00Z")
+        )
+
+        assertThat(activity1.match(activity2)).isFalse()
+    }
+
+    @Test
+    fun `No match - different timestamp`() {
+        val activity1 = Activity(
+            id = 1,
+            name = "Activity 1",
+            distance = 17804.00,
+            trainingEffect = "recovery",
+            type = ActivityType.Cycling,
+            eventType = EventType.Transportation,
+            date = Instant.parse("2025-01-01T01:01:00Z")
+        )
+
+        val activity2 = Activity(
+            id = 2,
+            name = "Activity 2",
+            distance = 7804.00,
+            trainingEffect = "recovery",
+            type = ActivityType.Cycling,
+            date = Instant.parse("2025-01-01T01:02:30Z")
         )
 
         assertThat(activity1.match(activity2)).isFalse()

--- a/app/src/test/kotlin/paufregi/connectfeed/presentation/syncstrava/SyncStravaViewModelTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/presentation/syncstrava/SyncStravaViewModelTest.kt
@@ -43,7 +43,8 @@ class SyncStravaViewModelTest {
             type = ActivityType.Running,
             eventType = EventType.Training,
             distance = 10234.00,
-            trainingEffect = "recovery"
+            trainingEffect = "recovery",
+            date = Instant.parse("2025-01-01T01:00:00Z")
         ),
         Activity(
             id = 2L,
@@ -51,7 +52,8 @@ class SyncStravaViewModelTest {
             type = ActivityType.Cycling,
             eventType = EventType.Training,
             distance = 17803.00,
-            trainingEffect = "base"
+            trainingEffect = "base",
+            date = Instant.parse("2025-01-01T02:00:00Z")
         ),
         Activity(
             id = 3L,
@@ -60,7 +62,7 @@ class SyncStravaViewModelTest {
             eventType = EventType.Training,
             distance = 5234.00,
             trainingEffect = "base",
-            date = Instant.ofEpochMilli(1729705968000)
+            date = Instant.parse("2025-01-01T03:00:00Z")
         ),
     )
 
@@ -69,20 +71,22 @@ class SyncStravaViewModelTest {
             id = 1L,
             name = "StravaRunning",
             type = ActivityType.Running,
-            distance = 10234.00
+            distance = 10234.00,
+            date = Instant.parse("2025-01-01T01:00:00Z")
         ),
         Activity(
             id = 2L,
             name = "StravaCycling",
             type = ActivityType.Cycling,
-            distance = 17803.00
+            distance = 17803.00,
+            date = Instant.parse("2025-01-01T02:00:00Z")
         ),
         Activity(
             id = 3L,
             name = "StravaRunning2",
             type = ActivityType.Running,
             distance = 5234.00,
-            date = Instant.ofEpochMilli(1729705968000)
+            date = Instant.parse("2025-01-01T03:00:00Z")
         ),
     )
 


### PR DESCRIPTION
### Relax Activity matching

This PR improves the Activity matching process by relaxing the strict date matching requirement. Previously, activities needed to start at precisely the same time to be considered a match. This change introduces a one-minute tolerance window. Now, activities will be considered a match if their start times are within one minute of each other.
