### PR TITLE
Fix Strava description format

### DIFF
--- a/app/src/main/kotlin/paufregi/connectfeed/core/utils/Formatter.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/core/utils/Formatter.kt
@@ -20,7 +20,7 @@ object Formatter {
 
     fun description(description: String?, trainingEffect: String?, trainingEffectFlag: Boolean): String? =
         if (trainingEffectFlag == true && trainingEffect != null)
-            "$description\n\nTraining: $trainingEffect"
+            "${description ?: ""}\n\nTraining: $trainingEffect"
         else
             description
 }

--- a/app/src/test/kotlin/paufregi/connectfeed/core/utils/FormatterTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/core/utils/FormatterTest.kt
@@ -24,4 +24,41 @@ class FormatterTest {
         val result = Formatter.dateTimeForImport(Locale.ENGLISH).parse("2024-01-01 10:20:30")
         assertThat(result).isEqualTo(date)
     }
+
+    @Test
+    fun `Formatter distance`() {
+        val distance = 1234567.0
+        val result = Formatter.distance(distance)
+        assertThat(result).isEqualTo("1234.57")
+    }
+
+    @Test
+    fun `Formatter description`() {
+        val description = "Description"
+        val trainingEffect = "recovery"
+        val result = Formatter.description(description, trainingEffect, true)
+        assertThat(result).isEqualTo("Description\n\nTraining: recovery")
+    }
+
+    @Test
+    fun `Formatter description - flag false`() {
+        val description = "Description"
+        val trainingEffect = "recovery"
+        val result = Formatter.description(description, trainingEffect, false)
+        assertThat(result).isEqualTo("Description")
+    }
+
+    @Test
+    fun `Formatter description - null description`() {
+        val trainingEffect = "recovery"
+        val result = Formatter.description(null, trainingEffect, true)
+        assertThat(result).isEqualTo("\n\nTraining: recovery")
+    }
+
+    @Test
+    fun `Formatter description - null training effect`() {
+        val description = "Description"
+        val result = Formatter.description(description, null, true)
+        assertThat(result).isEqualTo("Description")
+    }
 }


### PR DESCRIPTION
### Fix description format

This PR fix the "null" value into the Strava description, replacing the "null" string with "".