### PR TITLE
Launch Strava upon update

### DIFF
--- a/app/src/androidTest/kotlin/paufregi/connectfeed/TestUtils.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/TestUtils.kt
@@ -1,6 +1,8 @@
 package paufregi.connectfeed
 
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.RecordedRequest
@@ -15,10 +17,8 @@ import java.util.Date
 import paufregi.connectfeed.data.api.strava.models.AuthToken as StravaAuthToken
 
 fun createAuthToken(expiresAt: Date) = AuthToken(
-    accessToken = "ACCESS_TOKEN",
-    expiresAt = expiresAt.time / 1000
+    accessToken = JWT.create().withExpiresAt(expiresAt).sign(Algorithm.none()),
 )
-
 fun createStravaToken(expiresAt: Date) = StravaAuthToken(
     accessToken = "ACCESS_TOKEN",
     refreshToken = "REFRESH_TOKEN",
@@ -43,7 +43,6 @@ val authTokenJson = """
     "token_type": "TOKEN_TYPE",
     "refresh_token": "REFRESH_TOKEN",
     "expires_in": 0,
-    "expires_at": ${authToken.expiresAt},
     "refresh_token_expires_in": 0
     }
     """.trimIndent()

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/data/datastore/AuthStoreTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/data/datastore/AuthStoreTest.kt
@@ -61,8 +61,8 @@ class AuthStoreTest {
 
     @Test
     fun `Save retrieve and delete AuthToken`() = runTest {
-        val token1 = AuthToken(accessToken = "ACCESS_TOKEN_1", expiresAt = 1)
-        val token2 = AuthToken(accessToken = "ACCESS_TOKEN_2", expiresAt = 2)
+        val token1 = AuthToken(accessToken = "ACCESS_TOKEN_1")
+        val token2 = AuthToken(accessToken = "ACCESS_TOKEN_2")
 
         dataStore.getAuthToken().test {
             assertThat(awaitItem()).isNull()

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/data/repository/AuthRepositoryTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/data/repository/AuthRepositoryTest.kt
@@ -88,8 +88,8 @@ class AuthRepositoryTest {
 
     @Test
     fun `Store AuthToken`() = runTest {
-        val token1 = AuthToken(accessToken = "ACCESS_TOKEN_1", expiresAt = 1)
-        val token2 = AuthToken(accessToken = "ACCESS_TOKEN_2", expiresAt = 2)
+        val token1 = AuthToken(accessToken = "ACCESS_TOKEN_1")
+        val token2 = AuthToken(accessToken = "ACCESS_TOKEN_2")
         repo.getAuthToken().test{
             assertThat(awaitItem()).isNull()
             repo.saveAuthToken(token1)

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/di/TestDatabaseModule.kt
@@ -16,7 +16,7 @@ import javax.inject.Singleton
     components = [SingletonComponent::class],
     replaces = [DatabaseModule::class]
 )
-class TestDatabaseModule {
+object TestDatabaseModule {
     @Provides
     @Singleton
     fun provideGarminDatabase(@ApplicationContext context: Context): GarminDatabase =

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/di/TestGarminModule.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/di/TestGarminModule.kt
@@ -14,7 +14,7 @@ import javax.inject.Singleton
     components = [SingletonComponent::class],
     replaces = [GarminModule::class]
 )
-class TestGarminModule {
+object TestGarminModule {
 
     @Provides
     @Singleton

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/di/TestStravaModule.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/di/TestStravaModule.kt
@@ -1,7 +1,6 @@
 package paufregi.connectfeed.di
 
 import android.net.Uri
-import androidx.core.net.toUri
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/di/TestStravaModule.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/di/TestStravaModule.kt
@@ -1,6 +1,7 @@
 package paufregi.connectfeed.di
 
 import android.net.Uri
+import androidx.core.net.toUri
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
@@ -14,7 +15,7 @@ import javax.inject.Singleton
     components = [SingletonComponent::class],
     replaces = [StravaModule::class]
 )
-class TestStravaModule {
+object TestStravaModule {
 
     @Provides
     @Singleton
@@ -39,7 +40,7 @@ class TestStravaModule {
     @Provides
     @Singleton
     @Named("StravaAuthUri")
-    fun provideStravaUri(): Uri =
+    fun provideStravaAuthUri(): Uri =
         Uri.parse("paufregi.connectfeed://strava/auth")
             .buildUpon()
             .appendQueryParameter("code", "123456")

--- a/app/src/main/kotlin/paufregi/connectfeed/core/utils/Extension.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/core/utils/Extension.kt
@@ -41,9 +41,9 @@ fun Date.sameDay(other: Date): Boolean {
             calendar1.get(Calendar.DAY_OF_YEAR) == calendar2.get(Calendar.DAY_OF_YEAR)
 }
 
-fun <T> Response<T>.toResult(): Result<T> =
+inline fun <reified T> Response<T>.toResult(): Result<T> =
     when (this.isSuccessful) {
-        true -> Result.success(this.body()!!)
+        true -> Result.success(this.body() ?: Unit as T)
         false -> Result.failure(Exception(this.errorBody()?.string() ?: "Unknown error"))
     }
 

--- a/app/src/main/kotlin/paufregi/connectfeed/data/api/garmin/models/AuthToken.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/data/api/garmin/models/AuthToken.kt
@@ -1,19 +1,20 @@
 package paufregi.connectfeed.data.api.garmin.models
 
+import com.auth0.jwt.JWT
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonIgnoreUnknownKeys
-import java.time.Instant
+import java.util.Date
 
 @Serializable
 @JsonIgnoreUnknownKeys
 data class AuthToken(
     @SerialName("access_token")
     val accessToken: String,
-    @SerialName("expires_at")
-    val expiresAt: Long,
 ) {
-    fun isExpired(date: Long = Instant.now().epochSecond): Boolean = expiresAt < date
+    fun isExpired(date: Date = Date()): Boolean {
+        return accessToken.isBlank() || JWT.decode(accessToken).expiresAt.before(date)
+    }
 }
 
 

--- a/app/src/main/kotlin/paufregi/connectfeed/data/datastore/AuthStore.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/data/datastore/AuthStore.kt
@@ -17,7 +17,6 @@ class AuthStore(val dataStore: DataStore<Preferences>) {
         private val PRE_AUTH_TOKEN = byteArrayPreferencesKey("preAuthToken")
         private val PRE_AUTH_SECRET = byteArrayPreferencesKey("preAuthSecret")
         private val AUTH_TOKEN_ACCESS_TOKEN = byteArrayPreferencesKey("authTokenAccessToken")
-        private val AUTH_TOKEN_EXPIRES_AT = byteArrayPreferencesKey("authTokenExpiresAt")
         private val USER_NAME = stringPreferencesKey("userName")
         private val USER_PROFILE_IMAGE_URL = stringPreferencesKey("userProfileImageUrl")
     }
@@ -42,19 +41,15 @@ class AuthStore(val dataStore: DataStore<Preferences>) {
 
     fun getAuthToken() = dataStore.data.map {
         it[AUTH_TOKEN_ACCESS_TOKEN]?.let { accessToken ->
-            it[AUTH_TOKEN_EXPIRES_AT]?.let { expiresAt ->
-                AuthToken(
-                    accessToken = Crypto.decrypt(accessToken),
-                    expiresAt = Crypto.decrypt(expiresAt).toLong()
-                )
-            }
+            AuthToken(
+                accessToken = Crypto.decrypt(accessToken),
+            )
         }
     }
 
     suspend fun saveAuthToken(token: AuthToken) {
         dataStore.edit { preferences ->
             preferences[AUTH_TOKEN_ACCESS_TOKEN] = Crypto.encrypt(token.accessToken)
-            preferences[AUTH_TOKEN_EXPIRES_AT] = Crypto.encrypt(token.expiresAt.toString())
         }
     }
 

--- a/app/src/main/kotlin/paufregi/connectfeed/di/AppModule.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/di/AppModule.kt
@@ -1,6 +1,8 @@
 package paufregi.connectfeed.di
 
 import android.content.Context
+import android.net.Uri
+import androidx.core.net.toUri
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
@@ -33,7 +35,7 @@ val Context.stravaStore: DataStore<Preferences> by preferencesDataStore(name = "
 
 @Module
 @InstallIn(SingletonComponent::class)
-class AppModule {
+object AppModule {
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/paufregi/connectfeed/di/AppModule.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/di/AppModule.kt
@@ -1,8 +1,6 @@
 package paufregi.connectfeed.di
 
 import android.content.Context
-import android.net.Uri
-import androidx.core.net.toUri
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore

--- a/app/src/main/kotlin/paufregi/connectfeed/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/di/DatabaseModule.kt
@@ -13,7 +13,7 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-class DatabaseModule {
+object DatabaseModule {
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/paufregi/connectfeed/di/GarminModule.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/di/GarminModule.kt
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-class GarminModule {
+object GarminModule {
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/paufregi/connectfeed/di/StravaModule.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/di/StravaModule.kt
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-class StravaModule {
+object StravaModule {
 
     @Provides
     @Singleton
@@ -39,7 +39,7 @@ class StravaModule {
     @Provides
     @Singleton
     @Named("StravaAuthUri")
-    fun provideStravaUri(
+    fun provideStravaAuthUri(
         @Named("StravaClientId") clientId: String,
     ): Uri = "https://www.strava.com/oauth/mobile/authorize".toUri()
         .buildUpon()

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/account/AccountScreen.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/account/AccountScreen.kt
@@ -49,14 +49,11 @@ import paufregi.connectfeed.presentation.ui.models.ProcessState
 
 @Composable
 @ExperimentalMaterial3Api
-internal fun AccountScreen(
-    stravaAuthUri: Uri,
-    nav: NavController = rememberNavController()
-) {
+internal fun AccountScreen(nav: NavController = rememberNavController()) {
     val viewModel = hiltViewModel<AccountViewModel>()
     val state by viewModel.state.collectAsStateWithLifecycle()
 
-    AccountContent(state, stravaAuthUri, viewModel::onAction, nav)
+    AccountContent(state, viewModel::onAction, viewModel.stravaAuthUri, nav)
 }
 
 @Preview
@@ -64,8 +61,8 @@ internal fun AccountScreen(
 @ExperimentalMaterial3Api
 internal fun AccountContent(
     @PreviewParameter(AccountStatePreview::class) state: AccountState,
-    stravaAuthUri: Uri = Uri.EMPTY,
     onAction: (AccountAction) -> Unit = {},
+    stravaAuthUri: Uri = Uri.EMPTY,
     nav: NavController = rememberNavController()
 ) {
     when (state.process) {
@@ -92,7 +89,7 @@ internal fun AccountContent(
             items = Navigation.items,
             selectedIndex = Navigation.ACCOUNT,
             nav = nav
-        ) { AccountForm(state, stravaAuthUri, onAction, it) }
+        ) { AccountForm(state, onAction, stravaAuthUri, it) }
     }
 }
 
@@ -101,8 +98,8 @@ internal fun AccountContent(
 @ExperimentalMaterial3Api
 internal fun AccountForm(
     state: AccountState,
-    stravaAuthUri: Uri,
     onAction: (AccountAction) -> Unit = {},
+    stravaAuthUri: Uri = Uri.EMPTY,
     paddingValues: PaddingValues = PaddingValues(),
 ) {
     val context = LocalContext.current

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/account/AccountViewModel.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/account/AccountViewModel.kt
@@ -1,5 +1,6 @@
 package paufregi.connectfeed.presentation.account
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,6 +17,7 @@ import paufregi.connectfeed.core.usecases.RefreshUser
 import paufregi.connectfeed.core.usecases.SignOut
 import paufregi.connectfeed.presentation.ui.models.ProcessState
 import javax.inject.Inject
+import javax.inject.Named
 
 @HiltViewModel
 class AccountViewModel @Inject constructor(
@@ -24,6 +26,7 @@ class AccountViewModel @Inject constructor(
     val refreshUser: RefreshUser,
     val signOut: SignOut,
     val disconnectStrava: DisconnectStrava,
+    @Named("StravaAuthUri")val stravaAuthUri: Uri
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(AccountState())

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/account/AccountViewModel.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/account/AccountViewModel.kt
@@ -26,7 +26,7 @@ class AccountViewModel @Inject constructor(
     val refreshUser: RefreshUser,
     val signOut: SignOut,
     val disconnectStrava: DisconnectStrava,
-    @Named("StravaAuthUri")val stravaAuthUri: Uri
+    @Named("StravaAuthUri") val stravaAuthUri: Uri
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(AccountState())

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/edit/EditScreen.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/edit/EditScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
@@ -59,6 +60,7 @@ import paufregi.connectfeed.presentation.ui.icons.FaceSad
 import paufregi.connectfeed.presentation.ui.icons.FaceVeryHappy
 import paufregi.connectfeed.presentation.ui.icons.FaceVerySad
 import paufregi.connectfeed.presentation.ui.models.ProcessState
+import paufregi.connectfeed.presentation.ui.utils.launchStrava
 
 @Composable
 @ExperimentalMaterial3Api
@@ -77,6 +79,7 @@ internal fun EditContent(
     onAction: (EditAction) -> Unit = {},
     nav: NavController = rememberNavController()
 ) {
+    val context = LocalContext.current
     when (state.process) {
         is ProcessState.Processing -> SimpleScaffold { Loading(it) }
         is ProcessState.Success -> SimpleScaffold {
@@ -86,7 +89,11 @@ internal fun EditContent(
                 actionButton = {
                     Button(
                         text = "Ok",
-                        onClick = { onAction(EditAction.Restart) })
+                        onClick = {
+                            onAction(EditAction.Restart)
+                            launchStrava(context, state.stravaActivity)
+                        }
+                    )
                 },
                 paddingValues = it
             )

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/main/MainActivity.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/main/MainActivity.kt
@@ -1,6 +1,5 @@
 package paufregi.connectfeed.presentation.main
 
-import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -24,16 +23,10 @@ import paufregi.connectfeed.presentation.profiles.ProfilesScreen
 import paufregi.connectfeed.presentation.quickedit.QuickEditScreen
 import paufregi.connectfeed.presentation.syncstrava.SyncStravaScreen
 import paufregi.connectfeed.presentation.ui.theme.Theme
-import javax.inject.Inject
-import javax.inject.Named
 
 @AndroidEntryPoint
 @ExperimentalMaterial3Api
 class MainActivity : ComponentActivity() {
-
-    @Inject
-    @Named("StravaAuthUri")
-    lateinit var stravaAuthUri: Uri
 
     private val viewModel: MainViewModel by viewModels()
 
@@ -62,7 +55,7 @@ class MainActivity : ComponentActivity() {
                             composable<Route.Edit> { EditScreen(nav = nav) }
                             composable<Route.SyncStrava> { SyncStravaScreen(nav = nav) }
                         }
-                        composable<Route.Account> { AccountScreen(stravaAuthUri = stravaAuthUri, nav = nav) }
+                        composable<Route.Account> { AccountScreen(nav = nav) }
                         navigation<Route.Profiles>(startDestination = Route.ProfileList) {
                             composable<Route.ProfileList> { ProfilesScreen(nav = nav) }
                             composable<Route.Profile> { ProfileScreen(nav = nav) }

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditScreen.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
@@ -56,6 +57,7 @@ import paufregi.connectfeed.presentation.ui.icons.FaceSad
 import paufregi.connectfeed.presentation.ui.icons.FaceVeryHappy
 import paufregi.connectfeed.presentation.ui.icons.FaceVerySad
 import paufregi.connectfeed.presentation.ui.models.ProcessState
+import paufregi.connectfeed.presentation.ui.utils.launchStrava
 
 @Composable
 @ExperimentalMaterial3Api
@@ -74,6 +76,7 @@ internal fun QuickEditContent(
     onAction: (QuickEditAction) -> Unit = {},
     nav: NavController = rememberNavController()
 ) {
+    val context = LocalContext.current
     when (state.process) {
         is ProcessState.Processing -> SimpleScaffold { Loading(it) }
         is ProcessState.Success -> SimpleScaffold {
@@ -83,7 +86,11 @@ internal fun QuickEditContent(
                 actionButton = {
                     Button(
                         text = "Ok",
-                        onClick = { onAction(QuickEditAction.Restart) })
+                        onClick = {
+                            onAction(QuickEditAction.Restart)
+                            launchStrava(context, state.stravaActivity)
+                        }
+                    )
                 },
                 paddingValues = it
             )

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/syncstrava/SyncStravaScreen.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/syncstrava/SyncStravaScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
@@ -43,6 +44,7 @@ import paufregi.connectfeed.presentation.ui.components.StatusInfo
 import paufregi.connectfeed.presentation.ui.components.StatusInfoType
 import paufregi.connectfeed.presentation.ui.components.toDropdownItem
 import paufregi.connectfeed.presentation.ui.models.ProcessState
+import paufregi.connectfeed.presentation.ui.utils.launchStrava
 
 @Composable
 @ExperimentalMaterial3Api
@@ -61,6 +63,7 @@ internal fun SyncStravaContent(
     onAction: (SyncStravaAction) -> Unit = {},
     nav: NavController = rememberNavController()
 ) {
+    val context = LocalContext.current
     when (state.process) {
         is ProcessState.Processing -> SimpleScaffold { Loading(it) }
         is ProcessState.Success -> SimpleScaffold {
@@ -70,7 +73,11 @@ internal fun SyncStravaContent(
                 actionButton = {
                     Button(
                         text = "Ok",
-                        onClick = { onAction(SyncStravaAction.Restart) })
+                        onClick = {
+                            onAction(SyncStravaAction.Restart)
+                            launchStrava(context, state.stravaActivity)
+                        }
+                    )
                 },
                 paddingValues = it
             )

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/ui/utils/strava.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/ui/utils/strava.kt
@@ -1,0 +1,14 @@
+package paufregi.connectfeed.presentation.ui.utils
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.net.toUri
+import paufregi.connectfeed.core.models.Activity
+
+fun launchStrava(context: Context, activity: Activity?) {
+    activity?.let {
+        context.startActivity(
+            Intent(Intent.ACTION_VIEW, "https://www.strava.com/activities/${it.id}".toUri())
+        )
+    }
+}

--- a/app/src/test/kotlin/paufregi/connectfeed/TestUtils.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/TestUtils.kt
@@ -1,5 +1,7 @@
 package paufregi.connectfeed
 
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
 import paufregi.connectfeed.core.models.User
 import paufregi.connectfeed.data.api.garmin.models.AuthToken
 import paufregi.connectfeed.data.api.garmin.models.PreAuthToken
@@ -7,8 +9,7 @@ import java.util.Date
 import paufregi.connectfeed.data.api.strava.models.AuthToken as StravaAuthToken
 
 fun createAuthToken(expiresAt: Date) = AuthToken(
-    accessToken = "ACCCESS_TOKEN",
-    expiresAt = expiresAt.time / 1000
+    accessToken = JWT.create().withExpiresAt(expiresAt).sign(Algorithm.none()),
 )
 
 fun createStravaToken(expiresAt: Date) = StravaAuthToken(
@@ -35,7 +36,6 @@ val authTokenJson = """
         "token_type": "TOKEN_TYPE",
         "refresh_token": "REFRESH_TOKEN",
         "expires_in": 0,
-        "expires_at": ${authToken.expiresAt},
         "refresh_token_expires_in": 0
     }
     """.trimIndent()

--- a/app/src/test/kotlin/paufregi/connectfeed/core/utils/ExtensionTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/core/utils/ExtensionTest.kt
@@ -471,13 +471,6 @@ class ExtensionTest {
     }
 
     @Test
-    fun `Response - toResult - exception`() {
-        val resp = Response.success(null)
-
-        assertThrows(NullPointerException::class.java) { resp.toResult() }
-    }
-
-    @Test
     fun `Response - toResult - failure`() {
         val resp = Response.error<String>(500, "error".toResponseBody())
 

--- a/app/src/test/kotlin/paufregi/connectfeed/core/utils/ExtensionTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/core/utils/ExtensionTest.kt
@@ -461,6 +461,16 @@ class ExtensionTest {
     }
 
     @Test
+    fun `Response - toResult - success unit`() {
+        val resp = Response.success(Unit)
+
+        val result = resp.toResult()
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(Unit)
+    }
+
+    @Test
     fun `Response - toResult - exception`() {
         val resp = Response.success(null)
 

--- a/app/src/test/kotlin/paufregi/connectfeed/data/api/garmin/models/AuthTokenTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/data/api/garmin/models/AuthTokenTest.kt
@@ -2,30 +2,40 @@ package paufregi.connectfeed.data.api.garmin.models
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import java.util.Date
 
 class AuthTokenTest {
 
     @Test
     fun `Valid access token`() {
-        val authToken = AuthToken(
-            accessToken = "ACCESS_TOKEN",
-            expiresAt = 1704067200, // 2024-01-01T00:00
+        val token = AuthToken(
+            accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NCIsIm5hbWUiOiJQYXVsIEVsbGlzIiwiZXhwIjoxNzA0MDI0MDAwLCJpYXQiOjE3MDQwMjQwMDB9.BAAoEhz3DEQfSe77n1BtDZEYX-e3_2_lfGIgx-QXEew", // ExpiresAt: 2024-01-01T00:00
         )
 
-        val date = 1672531200L // 2023-01-01T00:00
+        val date = Date(1672488000) // 2023-01-01T00:00
 
-        assertThat(authToken.isExpired(date)).isFalse()
+        assertThat(token.isExpired(date)).isFalse()
     }
 
     @Test
     fun `Expired access token`() {
-        val authToken = AuthToken(
-            accessToken = "ACCESS_TOKEN",
-            expiresAt = 1672531200, // 2023-01-01T00:00
+        val token = AuthToken(
+            accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NCIsIm5hbWUiOiJQYXVsIEVsbGlzIiwiZXhwIjoxNzA0MDI0MDAwLCJpYXQiOjE3MDQwMjQwMDB9.BAAoEhz3DEQfSe77n1BtDZEYX-e3_2_lfGIgx-QXEew", // ExpiresAt: 2024-01-01T00:00
         )
 
-        val date = 1704067200L // 2024-01-01T00:00
+        val date = Date(1722430800000) // 2024-08-01T00:00
 
-        assertThat(authToken.isExpired(date)).isTrue()
+        assertThat(token.isExpired(date)).isTrue()
+    }
+
+    @Test
+    fun `Empty access token OAuth2`() {
+        val token = AuthToken(
+            accessToken = "",
+        )
+
+        val date = Date(1722430800000) // 2024-08-01T00:00
+
+        assertThat(token.isExpired(date)).isTrue()
     }
 }

--- a/app/src/test/kotlin/paufregi/connectfeed/presentation/account/AccountViewModelTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/presentation/account/AccountViewModelTest.kt
@@ -1,5 +1,6 @@
 package paufregi.connectfeed.presentation.account
 
+import android.net.Uri
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import io.mockk.clearAllMocks
@@ -35,6 +36,8 @@ class AccountViewModelTest {
     private val isStravaLoggedIn = mockk<IsStravaLoggedIn>()
     private val disconnectStrava = mockk<DisconnectStrava>()
 
+    private val stravaAuthUri = Uri.EMPTY
+
     private lateinit var viewModel: AccountViewModel
 
     private val user = User("user", "url")
@@ -57,7 +60,7 @@ class AccountViewModelTest {
         every { getUser() } returns flowOf(user)
         every { isStravaLoggedIn() } returns flowOf(true)
 
-        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava)
+        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
 
         viewModel.state.test {
             val state = awaitItem()
@@ -70,7 +73,7 @@ class AccountViewModelTest {
             getUser()
             isStravaLoggedIn()
         }
-        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava)
+        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
     }
 
     @Test
@@ -79,7 +82,7 @@ class AccountViewModelTest {
         every { getUser() } returns flowOf(user)
         every { isStravaLoggedIn() } returns flowOf(true)
 
-        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava)
+        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
 
         viewModel.state.test {
             viewModel.onAction(AccountAction.RefreshUser)
@@ -94,7 +97,7 @@ class AccountViewModelTest {
             isStravaLoggedIn()
         }
         coVerify { refreshUser() }
-        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava)
+        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
     }
 
     @Test
@@ -103,7 +106,7 @@ class AccountViewModelTest {
         every { getUser() } returns flowOf(user)
         every { isStravaLoggedIn() } returns flowOf(true)
 
-        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava)
+        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
 
         viewModel.state.test {
             skipItems(1)
@@ -118,7 +121,7 @@ class AccountViewModelTest {
             isStravaLoggedIn()
         }
         coVerify { refreshUser() }
-        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava)
+        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
     }
 
     @Test
@@ -127,7 +130,7 @@ class AccountViewModelTest {
         every { getUser() } returns flowOf(user)
         every { isStravaLoggedIn() } returns flowOf(true)
 
-        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava)
+        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
 
         viewModel.state.test {
             viewModel.onAction(AccountAction.SignOut)
@@ -142,7 +145,7 @@ class AccountViewModelTest {
             isStravaLoggedIn()
         }
         coVerify { signOut() }
-        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava)
+        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
     }
 
     @Test
@@ -151,7 +154,7 @@ class AccountViewModelTest {
         every { getUser() } returns flowOf(user)
         every { isStravaLoggedIn() } returns flowOf(true)
 
-        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava)
+        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
 
         viewModel.state.test {
             viewModel.onAction(AccountAction.StravaDisconnect)
@@ -165,6 +168,6 @@ class AccountViewModelTest {
             isStravaLoggedIn()
         }
         coVerify { disconnectStrava() }
-        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava)
+        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
     }
 }

--- a/app/src/test/kotlin/paufregi/connectfeed/presentation/account/AccountViewModelTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/presentation/account/AccountViewModelTest.kt
@@ -35,8 +35,7 @@ class AccountViewModelTest {
     private val signOut = mockk<SignOut>()
     private val isStravaLoggedIn = mockk<IsStravaLoggedIn>()
     private val disconnectStrava = mockk<DisconnectStrava>()
-
-    private val stravaAuthUri = Uri.EMPTY
+    private val stravaUri = mockk<Uri>()
 
     private lateinit var viewModel: AccountViewModel
 
@@ -60,7 +59,7 @@ class AccountViewModelTest {
         every { getUser() } returns flowOf(user)
         every { isStravaLoggedIn() } returns flowOf(true)
 
-        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
+        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaUri)
 
         viewModel.state.test {
             val state = awaitItem()
@@ -73,7 +72,7 @@ class AccountViewModelTest {
             getUser()
             isStravaLoggedIn()
         }
-        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
+        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaUri)
     }
 
     @Test
@@ -82,7 +81,7 @@ class AccountViewModelTest {
         every { getUser() } returns flowOf(user)
         every { isStravaLoggedIn() } returns flowOf(true)
 
-        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
+        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaUri)
 
         viewModel.state.test {
             viewModel.onAction(AccountAction.RefreshUser)
@@ -97,7 +96,7 @@ class AccountViewModelTest {
             isStravaLoggedIn()
         }
         coVerify { refreshUser() }
-        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
+        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaUri)
     }
 
     @Test
@@ -106,7 +105,7 @@ class AccountViewModelTest {
         every { getUser() } returns flowOf(user)
         every { isStravaLoggedIn() } returns flowOf(true)
 
-        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
+        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaUri)
 
         viewModel.state.test {
             skipItems(1)
@@ -121,7 +120,7 @@ class AccountViewModelTest {
             isStravaLoggedIn()
         }
         coVerify { refreshUser() }
-        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
+        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaUri)
     }
 
     @Test
@@ -130,7 +129,7 @@ class AccountViewModelTest {
         every { getUser() } returns flowOf(user)
         every { isStravaLoggedIn() } returns flowOf(true)
 
-        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
+        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaUri)
 
         viewModel.state.test {
             viewModel.onAction(AccountAction.SignOut)
@@ -145,7 +144,7 @@ class AccountViewModelTest {
             isStravaLoggedIn()
         }
         coVerify { signOut() }
-        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
+        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaUri)
     }
 
     @Test
@@ -154,7 +153,7 @@ class AccountViewModelTest {
         every { getUser() } returns flowOf(user)
         every { isStravaLoggedIn() } returns flowOf(true)
 
-        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
+        viewModel = AccountViewModel(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaUri)
 
         viewModel.state.test {
             viewModel.onAction(AccountAction.StravaDisconnect)
@@ -168,6 +167,6 @@ class AccountViewModelTest {
             isStravaLoggedIn()
         }
         coVerify { disconnectStrava() }
-        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaAuthUri)
+        confirmVerified(getUser, isStravaLoggedIn, refreshUser, signOut, disconnectStrava, stravaUri)
     }
 }

--- a/app/src/test/kotlin/paufregi/connectfeed/presentation/profile/ProfileViewModelTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/presentation/profile/ProfileViewModelTest.kt
@@ -11,6 +11,7 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -60,6 +61,7 @@ class ProfileViewModelTest {
     @After
     fun tearDown(){
         clearAllMocks()
+        unmockkStatic("androidx.navigation.SavedStateHandleKt")
     }
 
     @Test


### PR DESCRIPTION
### Launch Strava after update

This PR introduces the functionality to automatically launch the Strava app upon successful update of a Strava activity. This is beneficial as certain data points (e.g., perceived exertion) are not currently editable via the Strava API.

Additionally, it addresses and resolves issues introduced in previous PRs (#123 #124, #125 ) 