### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/paufregi/GarminConnectFeed/security/code-scanning/10](https://github.com/paufregi/GarminConnectFeed/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Since the workflow only involves building and testing the code, it does not require any write permissions. The minimal permission `contents: read` will suffice.

The `permissions` block will be added after the `name` field (line 2) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
