### PR TITLE
Link profiles to Garmin user - Part 2

### DIFF
--- a/app/src/androidTest/kotlin/paufregi/connectfeed/data/database/GarminDaoTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/data/database/GarminDaoTest.kt
@@ -58,14 +58,30 @@ class GarminDaoTest {
             feelAndEffort = true,
             trainingEffect = true
         )
+        val profile2 = ProfileEntity(
+            id = 2,
+            userId = 2,
+            name = "profile2",
+            eventType = EventType.Training,
+            activityType = ActivityType.Running,
+            course = Course(id = 1, name = "course2", distance = 2000.50, type = ActivityType.Running),
+            water = 200,
+            rename = true,
+            customWater = true,
+            feelAndEffort = true,
+            trainingEffect = true
+        )
 
         dao.saveProfile(profile)
         assertThat(dao.getProfile(profile.id)).isEqualTo(profile)
 
+        dao.saveProfile(profile2)
+        assertThat(dao.getProfile(profile2.id)).isEqualTo(profile2)
+
         dao.deleteProfile(profile)
         assertThat(dao.getProfile(profile.id)).isNull()
 
-        dao.getAllProfiles().test {
+        dao.getAllProfiles(1).test {
             assertThat(awaitItem()).isEmpty()
             dao.saveProfile(profile)
             assertThat(awaitItem()).containsExactly(profile)

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/data/repository/GarminRepositoryTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/data/repository/GarminRepositoryTest.kt
@@ -112,7 +112,7 @@ class GarminRepositoryTest {
         repo.deleteProfile(user, profile)
         assertThat(repo.getProfile(profile.id)).isNull()
 
-        repo.getAllProfiles().test{
+        repo.getAllProfiles(user).test{
             assertThat(awaitItem()).isEmpty()
             repo.saveProfile(user, profile)
             assertThat(awaitItem()).containsExactly(profile)

--- a/app/src/main/kotlin/paufregi/connectfeed/core/usecases/GetProfiles.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/core/usecases/GetProfiles.kt
@@ -1,10 +1,21 @@
 package paufregi.connectfeed.core.usecases
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.flowOf
 import paufregi.connectfeed.core.models.Profile
+import paufregi.connectfeed.data.repository.AuthRepository
 import paufregi.connectfeed.data.repository.GarminRepository
 import javax.inject.Inject
 
-class GetProfiles @Inject constructor(private val garminRepository: GarminRepository) {
-    operator fun invoke(): Flow<List<Profile>> = garminRepository.getAllProfiles()
+class GetProfiles @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val garminRepository: GarminRepository
+) {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    operator fun invoke(): Flow<List<Profile>> =
+        authRepository.getUser().flatMapMerge { user ->
+            user?.let { garminRepository.getAllProfiles(it) } ?: flowOf(emptyList())
+        }
 }

--- a/app/src/main/kotlin/paufregi/connectfeed/data/database/GarminDao.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/data/database/GarminDao.kt
@@ -16,8 +16,8 @@ interface GarminDao {
     @Delete
     suspend fun deleteProfile(profile: ProfileEntity)
 
-    @Query("SELECT * FROM profiles ORDER BY activityType, name")
-    fun getAllProfiles(): Flow<List<ProfileEntity>>
+    @Query("SELECT * FROM profiles WHERE userId = :userId ORDER BY activityType, name")
+    fun getAllProfiles(userId: Long): Flow<List<ProfileEntity>>
 
     @Query("SELECT * FROM profiles WHERE ID = :id")
     suspend fun getProfile(id: Long): ProfileEntity?

--- a/app/src/main/kotlin/paufregi/connectfeed/data/repository/GarminRepository.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/data/repository/GarminRepository.kt
@@ -40,8 +40,8 @@ class GarminRepository @Inject constructor(
             .toResult()
             .map { it.toCore() }
 
-    fun getAllProfiles(): Flow<List<Profile>> =
-        garminDao.getAllProfiles().map { it.map { it.toCore() } }
+    fun getAllProfiles(user: User): Flow<List<Profile>> =
+        garminDao.getAllProfiles(user.id).map { it.map { it.toCore() } }
 
     suspend fun getProfile(id: Long): Profile? =
         garminDao.getProfile(id)?.toCore()

--- a/app/src/main/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditViewModel.kt
+++ b/app/src/main/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditViewModel.kt
@@ -33,8 +33,7 @@ class QuickEditViewModel @Inject constructor(
 
     private val _state = MutableStateFlow(QuickEditState())
 
-    val state =
-        combine(_state, getProfiles()) { state, profiles -> state.copy(profiles = profiles) }
+    val state = combine(_state, getProfiles()) { state, profiles -> state.copy(profiles = profiles) }
             .onStart { load() }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), QuickEditState())
 

--- a/app/src/test/kotlin/paufregi/connectfeed/core/usecases/GetProfilesTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/core/usecases/GetProfilesTest.kt
@@ -6,7 +6,9 @@ import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.confirmVerified
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -16,15 +18,18 @@ import paufregi.connectfeed.core.models.ActivityType
 import paufregi.connectfeed.core.models.Course
 import paufregi.connectfeed.core.models.EventType
 import paufregi.connectfeed.core.models.Profile
+import paufregi.connectfeed.data.repository.AuthRepository
 import paufregi.connectfeed.data.repository.GarminRepository
+import paufregi.connectfeed.user
 
 class GetProfilesTest{
+    private val auth = mockk<AuthRepository>()
     private val repo = mockk<GarminRepository>()
     private lateinit var useCase: GetProfiles
 
     @Before
     fun setup(){
-        useCase = GetProfiles(repo)
+        useCase = GetProfiles(auth, repo)
     }
 
     @After
@@ -52,27 +57,47 @@ class GetProfilesTest{
                 course = Course(id = 2, name = "course 2", distance = 15007.00, type = ActivityType.Running)),
         )
 
-        coEvery { repo.getAllProfiles() } returns flowOf(profiles)
+        every { auth.getUser() } returns flowOf(user)
+        coEvery { repo.getAllProfiles(any()) } returns flowOf(profiles)
 
         val res = useCase()
         res.test {
             assertThat(awaitItem()).isEqualTo(profiles)
             cancelAndIgnoreRemainingEvents()
         }
-        coVerify { repo.getAllProfiles() }
-        confirmVerified(repo)
+
+        verify { auth.getUser() }
+        coVerify { repo.getAllProfiles(user) }
+        confirmVerified(auth, repo)
     }
 
     @Test
     fun `Get profiles - empty list`() = runTest {
-        coEvery { repo.getAllProfiles() } returns flowOf(emptyList<Profile>())
+        every { auth.getUser() } returns flowOf(user)
+        coEvery { repo.getAllProfiles(any()) } returns flowOf(emptyList<Profile>())
 
         val res = useCase()
         res.test {
             assertThat(awaitItem()).isEqualTo(emptyList<Profile>())
             cancelAndIgnoreRemainingEvents()
         }
-        coVerify { repo.getAllProfiles() }
+
+        verify { auth.getUser() }
+        coVerify { repo.getAllProfiles(user) }
+        confirmVerified(repo)
+    }
+
+    @Test
+    fun `Get profiles - no user`() = runTest {
+        every { auth.getUser() } returns flowOf(null)
+
+        val res = useCase()
+        res.test {
+            assertThat(awaitItem()).isEqualTo(emptyList<Profile>())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify { auth.getUser() }
         confirmVerified(repo)
     }
 }

--- a/app/src/test/kotlin/paufregi/connectfeed/data/repository/GarminRepositoryTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/data/repository/GarminRepositoryTest.kt
@@ -134,31 +134,31 @@ class GarminRepositoryTest {
             )
         )
 
-        coEvery { dao.getAllProfiles() } returns flowOf(profileEntities)
+        coEvery { dao.getAllProfiles(any()) } returns flowOf(profileEntities)
 
-        val res = repo.getAllProfiles()
+        val res = repo.getAllProfiles(user)
 
         res.test {
             assertThat(awaitItem()).isEqualTo(profiles)
             cancelAndIgnoreRemainingEvents()
         }
 
-        coVerify { dao.getAllProfiles() }
+        coVerify { dao.getAllProfiles(user.id) }
         confirmVerified(dao, connect, strava)
     }
 
     @Test
     fun `Get all profiles - empty list`() = runTest {
-        coEvery { dao.getAllProfiles() } returns flowOf(emptyList<ProfileEntity>())
+        coEvery { dao.getAllProfiles(any()) } returns flowOf(emptyList<ProfileEntity>())
 
-        val res = repo.getAllProfiles()
+        val res = repo.getAllProfiles(user)
 
         res.test {
             assertThat(awaitItem()).isEqualTo(emptyList<Profile>())
             cancelAndIgnoreRemainingEvents()
         }
 
-        coVerify { dao.getAllProfiles() }
+        coVerify { dao.getAllProfiles(user.id) }
         confirmVerified(dao, connect, strava)
     }
 

--- a/app/src/test/kotlin/paufregi/connectfeed/presentation/profiles/ProfilesViewModelTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/presentation/profiles/ProfilesViewModelTest.kt
@@ -61,13 +61,13 @@ class ProfilesViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
 
-        verify{ getProfiles() }
+        verify { getProfiles() }
         confirmVerified(getProfiles, deleteProfile)
     }
 
     @Test
     fun `Initial state - empty list`() = runTest {
-        every { getProfiles.invoke() } returns flowOf(emptyList())
+        every { getProfiles() } returns flowOf(emptyList())
 
         viewModel = ProfilesViewModel(getProfiles, deleteProfile)
 
@@ -77,21 +77,21 @@ class ProfilesViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
 
-        verify{ getProfiles() }
+        verify { getProfiles() }
         confirmVerified(getProfiles, deleteProfile)
     }
 
     @Test
     fun `Delete profile`() = runTest {
-        every { getProfiles.invoke() } returns flowOf(profiles)
-        coEvery { deleteProfile.invoke(any()) } returns Unit
+        every { getProfiles() } returns flowOf(profiles)
+        coEvery { deleteProfile(any()) } returns Unit
 
         viewModel = ProfilesViewModel(getProfiles, deleteProfile)
 
         viewModel.onAction(ProfileAction.Delete(profiles[0]))
 
-        verify{ getProfiles() }
-        coVerify { deleteProfile.invoke(profiles[0]) }
+        verify { getProfiles() }
+        coVerify { deleteProfile(profiles[0]) }
         confirmVerified(getProfiles, deleteProfile)
     }
 }

--- a/app/src/test/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditViewModelTest.kt
+++ b/app/src/test/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditViewModelTest.kt
@@ -8,7 +8,6 @@ import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -143,7 +142,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify{ getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -176,7 +175,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify{ getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -209,7 +208,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify{ getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -242,7 +241,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify{ getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -275,7 +274,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify{ getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -310,7 +309,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify { getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -345,7 +344,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify { getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -380,7 +379,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify { getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -417,7 +416,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify{ getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -454,7 +453,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify{ getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -491,7 +490,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify{ getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -528,7 +527,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify{ getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -563,7 +562,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify{ getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -599,7 +598,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify{ getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -634,7 +633,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify{ getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -669,7 +668,7 @@ class QuickEditViewModelTest {
             getActivities(false)
             getStravaActivities(false)
         }
-        verify{ getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -714,7 +713,7 @@ class QuickEditViewModelTest {
             quickUpdateActivity(activities[0], profiles[0], 25, 50f, 80f)
             quickUpdateStravaActivity(activities[0], stravaActivities[0], profiles[0], "description")
         }
-        verify { getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -759,7 +758,7 @@ class QuickEditViewModelTest {
             quickUpdateActivity(activities[0], profiles[0], 25, 50f, 80f)
             quickUpdateStravaActivity(activities[0], stravaActivities[0], profiles[0], "description")
         }
-        verify { getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -804,7 +803,7 @@ class QuickEditViewModelTest {
             quickUpdateActivity(activities[0], profiles[0], 25, 50f, 80f)
             quickUpdateStravaActivity(activities[0], stravaActivities[0], profiles[0], "description")
         }
-        verify { getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -849,7 +848,7 @@ class QuickEditViewModelTest {
             quickUpdateActivity(activities[0], profiles[0], 25, 50f, 80f)
             quickUpdateStravaActivity(activities[0], stravaActivities[0], profiles[0], "description")
         }
-        verify { getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 
@@ -886,7 +885,7 @@ class QuickEditViewModelTest {
             getStravaActivities(false)
             getStravaActivities(true)
         }
-        verify { getProfiles() }
+        coVerify{ getProfiles() }
         confirmVerified(getActivities, getStravaActivities, getProfiles, quickUpdateActivity, quickUpdateStravaActivity)
     }
 }


### PR DESCRIPTION
### Link profiles to Garmin user - Part 2

This PR links Garmin users to their profiles. 
This enhancement enables users to log out and log in with different Garmin accounts while preserving their individual profiles.

⚠️  Breaking changes