### PR TITLE
Bump Android Gradle plugin from 8.10.1 to 8.11.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity = "1.10.1"
-androidGradlePlugin = "8.10.1"
+androidGradlePlugin = "8.11.0"
 coil = "3.2.0"
 commonsCsv = "1.14.0"
 compose = "1.8.3"


### PR DESCRIPTION
###  Bumps Android Gradle plugin from 8.10.1 to 8.11.0

Updates com.android.application from 8.10.1 to 8.11.0