### PR TITLE
Clean up dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
 
 android {
     namespace = "paufregi.connectfeed"
+    //noinspection GradleDependency
     compileSdk = 35
 
     defaultConfig {
@@ -131,7 +132,6 @@ dependencies {
     debugRuntimeOnly(libs.androidx.ui.test.manifest)
 
     testRuntimeOnly(libs.androidx.test.core)
-    testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.junit)
     testImplementation(libs.truth)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,6 @@ androidHilt = "1.2.0"
 javaJwt = "4.5.0"
 junit = "4.13.2"
 junitAndroid = "1.2.1"
-junitPlatformLauncher = "1.13.2"
 kotlinPlugin = "2.2.0"
 kotlinxCoroutinesTest = "1.10.2"
 kotlinxSerializationJson = "1.9.0"
@@ -65,7 +64,6 @@ hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hil
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 java-jwt = { module = "com.auth0:java-jwt", version.ref = "javaJwt" }
 junit = { module = "junit:junit", version.ref = "junit" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatformLauncher" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }


### PR DESCRIPTION
### Clean up dependencies

This PR drops junit.platform.launcher from the dependency list, as it's not needed