### PR TITLE
Bump bouncycastle from 1.79 to 1.84

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,8 @@ subprojects {
                 .using(module("org.apache.httpcomponents:httpclient:4.5.13"))
             substitute(module("org.apache.commons:commons-lang3:3.16.0"))
                 .using(module("org.apache.commons:commons-lang3:3.18.0"))
+            substitute(module("org.bouncycastle:bcprov-jdk18on:1.79"))
+                .using(module("org.bouncycastle:bcprov-jdk18on:1.84"))
         }
     }
 }
@@ -46,6 +48,8 @@ buildscript {
                 .using(module("org.apache.httpcomponents:httpclient:4.5.13"))
             substitute(module("org.apache.commons:commons-lang3:3.16.0"))
                 .using(module("org.apache.commons:commons-lang3:3.18.0"))
+            substitute(module("org.bouncycastle:bcprov-jdk18on:1.79"))
+                .using(module("org.bouncycastle:bcprov-jdk18on:1.84"))
         }
     }
 }


### PR DESCRIPTION
Bumps `bouncycastle` from 1.79 to 1.84
Updates `org.bouncycastle:bcprov-jdk18on` from 1.79 to 1.84

