### PR TITLE
Bump Android SDK from 36 to 37

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,12 +13,12 @@ plugins {
 
 android {
     namespace = "paufregi.connectfeed"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "paufregi.connectfeed"
         minSdk = 33
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 37
         versionName = "2.4.10"
 


### PR DESCRIPTION
Updates the Android app configuration to target and test against Android SDK 37.

- Bump targetSdk from 36 to 37
- Update the managed virtual device apiLevel from 36 to 37