### PR TITLE
Ignore org.bouncycastle updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       - dependency-name: "org.apache.commons:commons-lang3"
       - dependency-name: "org.jdom:jdom2"
       - dependency-name: "org.bitbucket.b_c:jose4j"
+      - dependency-name: "org.bouncycastle:bcpkix-jdk18on"
+      - dependency-name: "org.bouncycastle:bcprov-jdk18on"
     groups:
       kotlinPlugin:
         patterns:


### PR DESCRIPTION
This PR updates the repository’s Dependabot configuration to stop creating Gradle version update PRs for two Bouncy Castle dependencies.

Packages: 
- org.bouncycastle:bcpkix-jdk18on
- org.bouncycastle:bcprov-jdk18on