### PR TITLE
Junit update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md
+
+## Project Overview
+
+**ConnectFeed** is an Android app for synchronizing Renpho Health data with Garmin Connect and Strava, and for editing activity details using custom profiles. The codebase is Kotlin, using Jetpack Compose, Hilt for DI, Room for local storage, and Retrofit for network APIs.
+
+## Architecture & Key Components
+
+- **Presentation Layer**: Compose-based UI in `app/src/main/kotlin/paufregi/connectfeed/presentation/`. Main navigation is in `MainActivity.kt` and `Navigation.kt`. Each feature (e.g., quick edit, profiles, settings) has its own subdirectory with `Screen`, `ViewModel`, and state/action classes.
+- **Domain/Use Cases**: Business logic is in `core/usecases/` (e.g., `IsLoggedIn`, `GetActivities`).
+- **Data Layer**:
+  - **Repositories**: In `data/repository/`, mediate between use cases and data sources.
+  - **APIs**: Retrofit interfaces in `data/api/` for Garmin, Strava, and Github.
+  - **Local Storage**: Room database (`data/database/`), with `ProfileEntity` as the main entity. Preferences/DataStore for auth and user data (`data/datastore/`).
+- **Dependency Injection**: Hilt modules in `di/` and `@HiltAndroidApp` in `ConnectFeed.kt`.
+
+## Developer Workflows
+
+- **Build**: `./gradlew build`
+- **Unit Tests**: `./gradlew test`
+- **Instrumented Tests**: `./gradlew pixel9ProCheck` (uses managed device config in `build.gradle.kts`)
+- **Test Entry Point**: Instrumented tests use custom runner `paufregi.connectfeed.TestRunner`.
+- **Test Patterns**: Instrumented tests (e.g., `MainActivityTest.kt`) use Compose Test APIs and Hilt for setup/teardown.
+
+## Project-Specific Conventions
+
+- **Profiles**: Profiles are stored in Room (`ProfileEntity`), keyed by user, and support custom fields (water, feel/effort, etc.).
+- **Activity Types**: Rich hierarchy in `core/models/ActivityType.kt` for compatibility checks between Garmin/Strava types.
+- **Navigation**: Uses Compose Navigation with sealed `Route` objects.
+- **State Management**: ViewModels expose state as `StateFlow`, often using `stateIn` and `SharingStarted.WhileSubscribed`.
+- **Error Handling**: Uses `ProcessState` sealed class for UI state (Idle, Processing, Success, Failure).
+- **API Substitution**: `build.gradle.kts` enforces dependency versions via `dependencySubstitution`.
+- **Sensitive Data**: API keys/secrets are loaded from `local.properties` and injected via `buildConfigField`.
+
+## Integration Points
+
+- **Garmin/Strava APIs**: See `data/api/garmin/` and `data/api/strava/` for endpoints and auth flows.
+- **DataStore**: Used for persisting user/auth tokens (`AuthStore`, `StravaStore`).
+- **Room**: All profile data is persisted locally and accessed via `GarminDao`.
+- **Hilt**: All major components are injected; tests use `@HiltAndroidTest`.
+
+## Key Files/Directories
+
+- `app/src/main/kotlin/paufregi/connectfeed/presentation/` — UI and navigation
+- `app/src/main/kotlin/paufregi/connectfeed/core/usecases/` — Business logic
+- `app/src/main/kotlin/paufregi/connectfeed/data/repository/` — Data access
+- `app/src/main/kotlin/paufregi/connectfeed/data/api/` — Network APIs
+- `app/src/main/kotlin/paufregi/connectfeed/data/database/` — Room DB
+- `app/src/main/kotlin/paufregi/connectfeed/data/datastore/` — DataStore
+- `app/build.gradle.kts` — Build config, managed device test setup
+- `README.md` — Feature and workflow summary
+
+## Example: Adding a New Activity Type
+- Extend `ActivityType` in `core/models/ActivityType.kt`
+- Update Room converters if needed
+- Adjust UI dropdowns and compatibility logic in relevant screens
+
+## Example: Adding a New Profile Field
+- Add field to `ProfileEntity`
+- Update UI and ViewModel logic in `profiles/` and `quickedit/`
+- Migrate DB schema if necessary
+

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/edit/EditScreenTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/edit/EditScreenTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertTextContains
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/login/LoginScreenTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/login/LoginScreenTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/main/MainActivityTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/main/MainActivityTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.isDisplayed
-import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/main/MainActivityTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/main/MainActivityTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.isDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/profile/ProfileScreenTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertTextContains
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/profiles/ProfilesScreenTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/profiles/ProfilesScreenTest.kt
@@ -2,7 +2,7 @@ package paufregi.connectfeed.presentation.profiles
 
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.hilt.android.testing.HiltAndroidTest

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditScreenTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/quickedit/QuickEditScreenTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/settings/SettingsScreenTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/strava/StravaScreenTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/strava/StravaScreenTest.kt
@@ -2,7 +2,7 @@ package paufregi.connectfeed.presentation.strava
 
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/syncstrava/SyncStravaScreenTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/syncstrava/SyncStravaScreenTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/syncweight/SyncWeightActivityTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/syncweight/SyncWeightActivityTest.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/syncweight/SyncWeightScreenTest.kt
+++ b/app/src/androidTest/kotlin/paufregi/connectfeed/presentation/syncweight/SyncWeightScreenTest.kt
@@ -2,7 +2,7 @@ package paufregi.connectfeed.presentation.syncweight
 
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4


### PR DESCRIPTION
Updates the Android instrumented Compose UI tests to use the newer androidx.compose.ui.test.junit4.v2.createComposeRule import, aligning the test suite with the updated Compose JUnit4 testing API.