### PR TITLE
Bump io.netty:netty-codec-http from 4.1.132.Final to 4.1.133.Final

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,11 +21,11 @@ subprojects {
         resolutionStrategy.dependencySubstitution {
             listOf("4.1.93.Final", "4.1.110.Final").forEach { version ->
                 substitute(module("io.netty:netty-codec-http2:$version"))
-                    .using(module("io.netty:netty-codec-http2:4.1.132.Final"))
+                    .using(module("io.netty:netty-codec-http2:4.1.133.Final"))
             }
             listOf("4.1.93.Final", "4.1.110.Final").forEach { version ->
                 substitute(module("io.netty:netty-codec-http:$version"))
-                    .using(module("io.netty:netty-codec-http:4.1.132.Final"))
+                    .using(module("io.netty:netty-codec-http:4.1.133.Final"))
             }
             substitute(module("org.apache.httpcomponents:httpclient:4.5.6"))
                 .using(module("org.apache.httpcomponents:httpclient:4.5.13"))


### PR DESCRIPTION
Bumps `io.netty:netty-codec-http` & `io.netty:netty-codec-http2` from 4.1.132.Final to 4.1.133.Final

Fix for 
- [security alert 37](https://github.com/paufregi/GarminConnectFeed/security/dependabot/37)
- [security alert 39](https://github.com/paufregi/GarminConnectFeed/security/dependabot/39)
- [security alert 40](https://github.com/paufregi/GarminConnectFeed/security/dependabot/40)
- [security alert 43](https://github.com/paufregi/GarminConnectFeed/security/dependabot/43)
- [security alert 44](https://github.com/paufregi/GarminConnectFeed/security/dependabot/44)
- [security alert 45](https://github.com/paufregi/GarminConnectFeed/security/dependabot/45) 