### PR TITLE
Bump io.netty:netty-handler-proxy from 4.1.93.Final & 4.1.110.Final to 4.1.133.Final

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,10 @@ subprojects {
                 substitute(module("io.netty:netty-codec-http:$version"))
                     .using(module("io.netty:netty-codec-http:4.1.133.Final"))
             }
+            listOf("4.1.93.Final", "4.1.110.Final").forEach { version ->
+                substitute(module("io.netty:netty-handler-proxy:$version"))
+                    .using(module("io.netty:netty-handler-proxy:4.1.133.Final"))
+            }
             substitute(module("org.apache.httpcomponents:httpclient:4.5.6"))
                 .using(module("org.apache.httpcomponents:httpclient:4.5.13"))
             substitute(module("org.apache.commons:commons-lang3:3.16.0"))


### PR DESCRIPTION
Bumps `netty-handler-proxy` from 4.1.93.Final & 4.1.110.Final to 4.1.130.Final

Fix for 
- [security alert 38](https://github.com/paufregi/GarminConnectFeed/security/dependabot/38)