### PR TITLE
Ignore  netty-handler-proxy updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     ignore:
       - dependency-name: "io.netty:netty-codec-http"
       - dependency-name: "io.netty:netty-codec-http2"
+      - dependency-name: "io.netty:netty-handler-proxy"
       - dependency-name: "com.google.protobuf:protobuf-kotlin"
       - dependency-name: "org.apache.httpcomponents:httpclient"
       - dependency-name: "org.apache.commons:commons-lang3"


### PR DESCRIPTION
This PR updates the repository’s Dependabot configuration to stop creating Gradle version update PRs for netty-handler-proxy dependency.